### PR TITLE
Backoff with cpu_relax

### DIFF
--- a/src/backoff.ml
+++ b/src/backoff.ml
@@ -1,6 +1,7 @@
 (*
  * Copyright (c) 2015, Théo Laurent <theo.laurent@ens.fr>
  * Copyright (c) 2015, KC Sivaramakrishnan <sk826@cl.cam.ac.uk>
+ * Copyright (c) 2021, Sudha Parimala <sudharg247@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -36,10 +37,11 @@ module M : S = struct
     let t = Random.int !r in
     r := min (2 * !r) maxv ;
     if t = 0 then ()
-    else
-      ignore
-        Domain.Sync.(
-          critical_section (fun _ -> wait_for (Int64.of_int (1_000_000 * t))))
+    else begin
+      for _ = 1 to 2048 * t do
+        Domain.Sync.cpu_relax ()
+      done
+    end
 
   let reset (_, r) = r := 1
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -29,11 +29,11 @@ open Printf;;
 
 let nb_iter = 10000;;
 let wait_time = 2;;
-let th1_success = Pervasives.ref true;;
-let th2_success = Pervasives.ref true;;
-let th3_success = Pervasives.ref true;;
-let th4_success = Pervasives.ref true;;
-let th5_success = Pervasives.ref true;;
+let th1_success = Stdlib.ref true;;
+let th2_success = Stdlib.ref true;;
+let th3_success = Stdlib.ref true;;
+let th4_success = Stdlib.ref true;;
+let th5_success = Stdlib.ref true;;
 
 let v_x = 0;;
 let v_y = 1;;


### PR DESCRIPTION
Fixes #8. Based on a version of exponential backoff in the lockfree library.