### PR TITLE
update cpu_relax to new location

### DIFF
--- a/src/backoff.ml
+++ b/src/backoff.ml
@@ -39,7 +39,7 @@ module M : S = struct
     if t = 0 then ()
     else begin
       for _ = 1 to 2048 * t do
-        Domain.Sync.cpu_relax ()
+        Domain.cpu_relax ()
       done
     end
 


### PR DESCRIPTION
This PR updates `Domain.Sync.cpu_relax` to its new location, so that kcas (and lockfree which depends on kcas) compiles with ocaml trunk/5.00.