### PR TITLE
Clean up dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-all:
-	ocaml pkg/pkg.ml build --pinned false
+all: build test
+
+build:
+	@dune build @install
+
+test:
+	@dune runtest --force
 
 clean:
-	rm -rf _build
+	@dune clean

--- a/kcas.opam
+++ b/kcas.opam
@@ -10,8 +10,6 @@ dev-repo: "git+https://github.com/kayceesrk/kcas.git"
 bug-reports: "https://github.com/kayceesrk/kcas/issues"
 tags: []
 depends: [
-  "ocamlfind" {build}
-  "ocamlbuild" {build}
   "dune" {build} ]
 depopts: []
 build: [

--- a/src/kcas.mllib
+++ b/src/kcas.mllib
@@ -1,2 +1,0 @@
-Kcas
-Kcas_backoff


### PR DESCRIPTION
This PR cleans up the dependencies listed in the opam-file, leaving only dune, following #4.
The Makefile is updated and I've removed the old ocamlbuild .mllib-file.