### PR TITLE
Using fenceless get and set operations where it is safe

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -9,4 +9,5 @@
 (package (name kcas)
  (synopsis "Multi-word compare-and-swap library")
  (depends 
-  (ocaml (>= 5.0))))
+  (ocaml (>= 5.0))
+  (multicore-magic (>= 1.0.0))))

--- a/kcas.opam
+++ b/kcas.opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
 depends: [
   "dune" {>= "3.3"}
   "ocaml" {>= "5.0"}
+  "multicore-magic" {>= "1.0.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name kcas)
  (public_name kcas)
- (libraries unix))
+ (libraries unix multicore-magic))


### PR DESCRIPTION
This PR changes the code to use [`fenceless_get`](https://ocaml-multicore.github.io/multicore-magic/multicore-magic/Multicore_magic/index.html#val-fenceless_get) and [`fenceless_set`](https://ocaml-multicore.github.io/multicore-magic/multicore-magic/Multicore_magic/index.html#val-fenceless_set) operations where it is arguably safe to do so.

It seems that use of fenceless operations improves performance in the 1-CAS case significantly and also slightly improves performance in the n-CAS case (when n > 1) on Apple M1 / ARM.  It should be noted, however, that the current set of benchmarks on kcas is rather limited.

Note that compared to [my previous experiments with fenceless operations on kcas](https://github.com/ocaml-multicore/kcas/pull/20#issuecomment-1385073524), the new kcas implementation has slightly higher overhead due to the presort/splay tree construction.

Note that on x86 fenceless get is exactly the same as an atomic get.  Fenceless get seems to be beneficial on CPUs with weaker memory models.

_With_ the fenceless operations:

```sh
Benchmark 1: _build/default/test/benchmark.exe 1 10000
  Time (mean ± σ):       2.8 ms ±   0.0 ms    [User: 1.9 ms, System: 0.6 ms]
  Range (min … max):     2.7 ms …   3.0 ms    1102 runs
 
Benchmark 2: _build/default/test/benchmark.exe 2 10000
  Time (mean ± σ):       8.0 ms ±   0.1 ms    [User: 7.1 ms, System: 0.6 ms]
  Range (min … max):     7.9 ms …   8.4 ms    371 runs
 
Benchmark 3: _build/default/test/benchmark.exe 4 10000
  Time (mean ± σ):      13.0 ms ±   0.1 ms    [User: 12.1 ms, System: 0.6 ms]
  Range (min … max):    12.9 ms …  13.4 ms    230 runs
 
Summary
  '_build/default/test/benchmark.exe 1 10000' ran
    2.91 ± 0.04 times faster than '_build/default/test/benchmark.exe 2 10000'
    4.74 ± 0.07 times faster than '_build/default/test/benchmark.exe 4 10000'


Benchmark 1: _build/default/test/benchmark.exe 1 200000
  Time (mean ± σ):      20.3 ms ±   0.2 ms    [User: 19.3 ms, System: 0.7 ms]
  Range (min … max):    20.0 ms …  20.7 ms    148 runs
 
Benchmark 2: _build/default/test/benchmark.exe 2 200000
  Time (mean ± σ):     126.7 ms ±   0.9 ms    [User: 125.1 ms, System: 1.2 ms]
  Range (min … max):   125.4 ms … 129.8 ms    23 runs
 
Benchmark 3: _build/default/test/benchmark.exe 4 200000
  Time (mean ± σ):     229.0 ms ±   0.4 ms    [User: 227.3 ms, System: 1.3 ms]
  Range (min … max):   228.2 ms … 229.9 ms    13 runs
 
Summary
  '_build/default/test/benchmark.exe 1 200000' ran
    6.25 ± 0.06 times faster than '_build/default/test/benchmark.exe 2 200000'
   11.30 ± 0.09 times faster than '_build/default/test/benchmark.exe 4 200000'
```

_Without_ fenceless operations:

```sh
Benchmark 1: _build/default/test/benchmark.exe 1 10000
  Time (mean ± σ):       3.5 ms ±   0.1 ms    [User: 2.6 ms, System: 0.6 ms]
  Range (min … max):     3.4 ms …   3.9 ms    812 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: _build/default/test/benchmark.exe 2 10000
  Time (mean ± σ):       8.0 ms ±   0.1 ms    [User: 7.1 ms, System: 0.6 ms]
  Range (min … max):     7.9 ms …   8.4 ms    376 runs
 
Benchmark 3: _build/default/test/benchmark.exe 4 10000
  Time (mean ± σ):      13.4 ms ±   0.1 ms    [User: 12.5 ms, System: 0.6 ms]
  Range (min … max):    13.2 ms …  13.7 ms    223 runs
 
Summary
  '_build/default/test/benchmark.exe 1 10000' ran
    2.32 ± 0.04 times faster than '_build/default/test/benchmark.exe 2 10000'
    3.85 ± 0.06 times faster than '_build/default/test/benchmark.exe 4 10000'


Benchmark 1: _build/default/test/benchmark.exe 1 200000
  Time (mean ± σ):      34.6 ms ±   0.4 ms    [User: 33.5 ms, System: 0.7 ms]
  Range (min … max):    33.6 ms …  35.2 ms    86 runs
 
Benchmark 2: _build/default/test/benchmark.exe 2 200000
  Time (mean ± σ):     126.3 ms ±   0.3 ms    [User: 124.9 ms, System: 1.0 ms]
  Range (min … max):   125.8 ms … 127.0 ms    23 runs
 
Benchmark 3: _build/default/test/benchmark.exe 4 200000
  Time (mean ± σ):     232.7 ms ±   0.4 ms    [User: 230.9 ms, System: 1.3 ms]
  Range (min … max):   232.0 ms … 233.3 ms    12 runs
 
Summary
  '_build/default/test/benchmark.exe 1 200000' ran
    3.66 ± 0.04 times faster than '_build/default/test/benchmark.exe 2 200000'
    6.73 ± 0.07 times faster than '_build/default/test/benchmark.exe 4 200000'
```