### PR TITLE
Fix bug to handle non-linearizable cases with `cas r x x` correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.1.8
+
+* Fix a bug in GKMZ implementation (@polytypic, review: @bartoszmodelski)
+
 ## 0.1.7
 
 * Change to use the new GKMZ algorithm (@polytypic, review: @bartoszmodelski)


### PR DESCRIPTION
It turns out @bartoszmodelski was absolutely right in questioning whether one of the "optimizations" in my GKMZ adaptation might break linearization:

  https://github.com/ocaml-multicore/kcas/pull/20#discussion_r1066113300

My reasoning at the time was simply wrong.

Consider performing these two k-CAS operations in parallel:

    [ Kcas.mk_cas a 0 0; Kcas.mk_cas b 0 1 ]
    [ Kcas.mk_cas a 0 1; Kcas.mk_cas b 0 0 ]

The "optimization" I had implemented allows both of those to succeed resulting in the invalid state `a=1 and b=1`.  The correct behaviour is that only one may succeed and the other must fail.

The intention of the optimization was to check if the (current) `state` had already been determined without reading the `casn` descriptor.  Unfortunately that breaks when `state.before == state.after` initially and the `casn` is still undetermined, because it then allows two conflicting k-CAS operations to succeed simultaneously.

The proposed fix does a similar optimization, postponing the access of `casn`, but correctly.  The crucial difference is that the correct optimization requires that the previous k-CAS has actually completed.

A couple of other places in the code have similar optimizations.  However, in those other cases this problem cannot occur: `cas` only updates a single location (so it can always be considered to happen after any potentially undetermined k-CAS with `state.before == state.after`) and `get` does not update any locations.