### PR TITLE
New obstruction-free k-CAS-n-CMP algorithm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.1
+
+* New k-CAS-n-CMP algorithm extending the GKMZ algorithm (@polytypic, review: @bartoszmodelski)
+
 ## 0.2.0
 
 * Complete redesign adding a new transaction API (@polytypic, review: @bartoszmodelski)

--- a/src/kcas.mli
+++ b/src/kcas.mli
@@ -61,7 +61,10 @@ module Mode : sig
 
   exception Interference
   (** Exception raised when interference from other domains is detected in the
-      {!obstruction_free} mode. *)
+      {!obstruction_free} mode.  Interference may happen when some location is
+      accessed by both a compare-and-set and a (read-only) compare operation.
+      It is not necessary for the compare-and-set to actually change the logical
+      value of the location. *)
 end
 
 (** Operations on shared memory locations. *)

--- a/test/barrier.ml
+++ b/test/barrier.ml
@@ -1,0 +1,9 @@
+type t = { counter : int Atomic.t; total : int }
+
+let make total = { counter = Atomic.make 0; total }
+
+let await { counter; total } =
+  Atomic.incr counter;
+  while Atomic.get counter < total do
+    ()
+  done

--- a/test/barrier.mli
+++ b/test/barrier.mli
@@ -1,0 +1,4 @@
+type t
+
+val make : int -> t
+val await : t -> unit

--- a/test/dune
+++ b/test/dune
@@ -28,6 +28,11 @@
  (modules tx_benchmark))
 
 (test
+ (name tx_parallel_cmp_bench)
+ (libraries kcas barrier)
+ (modules tx_parallel_cmp_bench))
+
+(test
  (name example)
  (libraries kcas)
  (modules example))

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,10 @@
+(library
+ (name barrier)
+ (modules barrier))
+
 (test
  (name test)
- (libraries kcas)
+ (libraries kcas barrier)
  (modules test))
 
 (test

--- a/test/test.ml
+++ b/test/test.ml
@@ -35,18 +35,6 @@ let assert_kcas loc expected_v =
   let present_v = Loc.get loc in
   assert (present_v == expected_v)
 
-module Barrier = struct
-  type t = { counter : int Atomic.t; total : int }
-
-  let make total = { counter = Atomic.make 0; total }
-
-  let await { counter; total } =
-    Atomic.incr counter;
-    while Atomic.get counter < total do
-      ()
-    done
-end
-
 let test_non_linearizable () =
   let barrier = Barrier.make 2
   and n_iter = 1_000_000

--- a/test/tx_parallel_cmp_bench.ml
+++ b/test/tx_parallel_cmp_bench.ml
@@ -1,0 +1,57 @@
+module Loc = Kcas.Loc
+module Tx = Kcas.Tx
+
+let parallel_cmp_benchmark n_iter =
+  let barrier = Barrier.make 2 in
+
+  let a = Loc.make 10 and b = Loc.make 52 in
+
+  let thread1 () =
+    let x = Loc.make 0 in
+    let tx1 =
+      Tx.(
+        let* a = get a and* b = get b in
+        set x (b - a))
+    and tx2 =
+      Tx.(
+        let* a = get a and* b = get b in
+        set x (a + b))
+    in
+    Barrier.await barrier;
+    let start = Unix.gettimeofday () in
+    for _ = 1 to n_iter do
+      Tx.commit tx1;
+      Tx.commit tx2
+    done;
+    Unix.gettimeofday () -. start
+  and thread2 () =
+    let y = Loc.make 0 in
+    let tx1 =
+      Tx.(
+        let* a = get a and* b = get b in
+        set y (b - a))
+    and tx2 =
+      Tx.(
+        let* a = get a and* b = get b in
+        set y (a + b))
+    in
+    Barrier.await barrier;
+    let start = Unix.gettimeofday () in
+    for _ = 1 to n_iter do
+      Tx.commit tx1;
+      Tx.commit tx2
+    done;
+    Unix.gettimeofday () -. start
+  in
+
+  let total =
+    [ thread1; thread2 ] |> List.map Domain.spawn |> List.map Domain.join
+    |> List.fold_left ( +. ) 0.0
+  in
+
+  Printf.printf "%f ns/tx\n"
+    (1_000_000_000.0 *. total /. Float.of_int (4 * n_iter))
+
+let () =
+  let n_iter = try int_of_string Sys.argv.(1) with _ -> 1_000_000 in
+  parallel_cmp_benchmark n_iter

--- a/test/tx_two_stack_queue.ml
+++ b/test/tx_two_stack_queue.ml
@@ -13,12 +13,13 @@ let is_empty q =
 
 let push_front q x = Tx.modify q.front @@ List.cons x
 let push_back q x = Tx.modify q.back @@ List.cons x
+let tl_safe = function [] -> [] | _ :: xs -> xs
 
 let pop_front q =
   Tx.(
-    get q.front >>= function
-    | x :: xs -> set q.front xs >>. x
+    update q.front tl_safe >>= function
+    | x :: _ -> return x
     | [] -> (
-        q.back |> get_as List.rev >>= function
+        exchange_as List.rev q.back [] >>= function
         | [] -> forget
-        | x :: xs -> set q.back [] >> set q.front xs >>. x))
+        | x :: xs -> set q.front xs >>. x))


### PR DESCRIPTION
The core of the new k-CAS-n-CMP algorithm is described in the following gist:

> [Extending k-CAS with efficient read-only CMP operations](https://gist.github.com/polytypic/0efa0e2981d2a5fc4b534a0e25120cc9)

This is an extension of the previous GKMZ algorithm and preserves lock-free k-CAS as a subset of functionality.

---

This PR includes a simple benchmark with two transactions that read from shared locations, but only write to their own local locations.  With the algorithm in this PR, I get something like 100ns/tx.  With the previous algorithm timings vary considerably, but tend to be at least twice as much and often much more.  I suspect it is possible that with the previous algorithm the domains might not be able to both proceed at the same time and that would explain the peak performance of being only twice as slow.