### PR TITLE
Fix the lock-free update of Michael-Scott style queue tail

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,30 +808,28 @@ update the tail after the transaction has been successfully committed:
     let rec find_and_set_tail old_tail =
       match Xt.compare_and_swap ~xt old_tail Nil new_node with
       | Nil -> ()
-      | Node (_, old_tail) ->
-        find_and_set_tail old_tail in
-    let old_tail = Atomic.get tail in
-    find_and_set_tail old_tail;
-    Xt.post_commit ~xt @@ fun () ->
-    let rec fix_tail old_tail new_tail =
-      if Atomic.compare_and_set tail old_tail new_tail then
-        match Loc.get new_tail with
-        | Nil -> ()
-        | Node (_, new_new_tail) ->
-          fix_tail new_tail new_new_tail in
-    fix_tail old_tail new_tail
+      | Node (_, old_tail) -> find_and_set_tail old_tail
+    in
+    find_and_set_tail (Atomic.get tail);
+    let rec fix_tail () =
+      let old_tail = Atomic.get tail in
+      if
+        Loc.get new_tail == Nil
+        && not (Atomic.compare_and_set tail old_tail new_tail)
+      then fix_tail ()
+    in
+    Xt.post_commit ~xt fix_tail
 val enqueue : xt:'a Xt.t -> 'b queue -> 'b -> unit = <fun>
 ```
 
 The post commit action, registered using
 [`post_commit`](https://ocaml-multicore.github.io/kcas/doc/kcas/Kcas/Xt/index.html#val-post_commit),
-follows a protocol to update the tail. After each successful CAS to update the
-tail, it checks whether the tail is actually correctly pointing to the true
-tail. If not, another attempt to update the tail is made. Although we allow the
-tail to momentarily fall behind, it is important that we do not let the tail to
-fall behind indefinitely, because then we would risk leaking memory &mdash;
-nodes that have been dequeued from the queue would still be pointed to by the
-tail.
+checks that the tail is still the true tail and then attempts to update the
+tail. The order of accesses is very subtle as always with non-transactional
+atomic operations. Can you see why it works? Although we allow the tail to
+momentarily fall behind, it is important that we do not let the tail fall behind
+indefinitely, because then we would risk leaking memory &mdash; nodes that have
+been dequeued from the queue would still be pointed to by the tail.
 
 Using the Michael-Scott style queue is as easy as any other transactional queue:
 

--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ the transaction is sufficient to ensure that each transaction dequeues a unique
 node. Unfortunately that would change the semantics of the operation.
 
 Suppose, for example, that you have two queues, _A_ and _B_, and you must
-maintain the invariant that at most one of the queues is non-empty. One domain
+maintain the invariant that at least one of the queues is empty. One domain
 tries to dequeue from _A_ and, if _A_ was empty, enqueue to _B_. Another domain
 does the opposite, dequeue from _B_ and enqueue to _A_ (when _B_ was empty).
 When such operations are performed in isolation, the invariant would be

--- a/test/dune
+++ b/test/dune
@@ -53,6 +53,11 @@
  (modules xt_parallel_cmp_bench))
 
 (test
+ (name ms_queue_test)
+ (libraries kcas)
+ (modules ms_queue_test))
+
+(test
  (name example)
  (libraries kcas)
  (modules example))

--- a/test/ms_queue_test.ml
+++ b/test/ms_queue_test.ml
@@ -1,0 +1,129 @@
+open Kcas
+
+module Q = struct
+  type 'a node = Nil | Node of 'a * 'a node Loc.t
+  type 'a queue = { head : 'a node Loc.t Loc.t; tail : 'a node Loc.t Atomic.t }
+
+  let queue () =
+    let next = Loc.make Nil in
+    { head = Loc.make next; tail = Atomic.make next }
+
+  let try_dequeue ~xt { head; _ } =
+    let old_head = Xt.get ~xt head in
+    match Xt.get ~xt old_head with
+    | Nil -> None
+    | Node (value, next) ->
+        Xt.set ~xt head next;
+        Some value
+
+  let enqueue ~xt { tail; _ } value =
+    let new_tail = Loc.make Nil in
+    let new_node = Node (value, new_tail) in
+    let rec find_and_set_tail old_tail =
+      match Xt.compare_and_swap ~xt old_tail Nil new_node with
+      | Nil -> ()
+      | Node (_, old_tail) -> find_and_set_tail old_tail
+    in
+    find_and_set_tail (Atomic.get tail);
+    let rec fix_tail () =
+      let old_tail = Atomic.get tail in
+      if
+        Loc.get new_tail == Nil
+        && not (Atomic.compare_and_set tail old_tail new_tail)
+      then fix_tail ()
+    in
+    Xt.post_commit ~xt fix_tail
+
+  let check_tail { tail; _ } = Loc.get (Atomic.get tail) == Nil
+end
+
+let failure exit msg =
+  Atomic.set exit true;
+  Printf.printf "%s\n%!" msg;
+  failwith msg
+
+let write_skew_test n =
+  let q1 = Q.queue () and q2 = Q.queue () in
+
+  let push_to_q2 ~xt =
+    match Q.try_dequeue ~xt q1 with None -> Q.enqueue ~xt q2 42 | Some _ -> ()
+  and push_to_q1 ~xt =
+    match Q.try_dequeue ~xt q2 with None -> Q.enqueue ~xt q1 24 | Some _ -> ()
+  and clear ~xt = (Q.try_dequeue ~xt q1, Q.try_dequeue ~xt q2) in
+
+  let barrier = Atomic.make 3 in
+  let sync () =
+    Atomic.decr barrier;
+    while Atomic.get barrier != 0 do
+      Domain.cpu_relax ()
+    done
+  in
+
+  let exit = Atomic.make false in
+
+  let domains =
+    [
+      Domain.spawn (fun () ->
+          sync ();
+          while not (Atomic.get exit) do
+            Xt.commit { tx = push_to_q1 }
+          done);
+      Domain.spawn (fun () ->
+          sync ();
+          while not (Atomic.get exit) do
+            Xt.commit { tx = push_to_q2 }
+          done);
+    ]
+  in
+
+  sync ();
+  for _ = 1 to n do
+    match Xt.commit { tx = clear } with
+    | Some _, Some _ -> failure exit "write skew!"
+    | _ -> ()
+  done;
+  Atomic.set exit true;
+
+  List.iter Domain.join domains
+
+let tail_leak_test n =
+  let q = Q.queue () in
+
+  let m = 2 in
+
+  let exit = Atomic.make false
+  and rounds = Array.init m @@ fun _ -> Atomic.make (n * 2) in
+  let finished () =
+    Array.exists (fun round -> Atomic.get round <= 0) rounds || Atomic.get exit
+  and sync i =
+    let n = Atomic.fetch_and_add rounds.(i) (-1) - 1 in
+    while rounds |> Array.exists @@ fun round -> n < Atomic.get round do
+      if Atomic.get exit then failwith "exit"
+    done
+  in
+
+  let domain i () =
+    try
+      while not (finished ()) do
+        sync i;
+
+        Xt.commit { tx = Q.enqueue q 42 };
+        if None == Xt.commit { tx = Q.try_dequeue q } then
+          failure exit "impossible!";
+
+        sync i;
+
+        if not (Q.check_tail q) then failure exit "tail leak!"
+      done
+    with e ->
+      Atomic.set exit true;
+      raise e
+  in
+
+  List.init m domain |> List.map Domain.spawn |> List.iter Domain.join
+
+let () =
+  let n = try int_of_string Sys.argv.(1) with _ -> 100_000 in
+  write_skew_test n;
+  tail_leak_test n;
+  ()


### PR DESCRIPTION
@lyrm, I realized that the protocol I devised for updating the tail of a Michael-Scott style queue was broken.  It suffered from pretty much the same kind of race condition as the previous attempts. 😞  So, this PR finally has a working solution to the Michael-Scott style queue tail leak.  The test in this PR was able to show that the previous attempts were wrong.  The logic of the new tail update algorithm is as follows:

> The tail update is only responsible for updating the tail as long as the new node added still has the true tail.  At any point some newly added node has the true tail, so this responsibility ensures that the tail gets updated.  To check whether we are still responsible, we compare: `get new_tail == Nil`.  If that is false, then someone else is responsible and we can stop.  The current `old_tail` must be read before that check.  If the `compare_and_set` fails, we must retry.  Otherwise we can stop as we've done our part.

At any rate, the take home lesson for me is to really stop trusting that my fine-grained concurrent code is correct unless I basically have a proof of it. 😅