### PR TITLE
Add `Loc.modify`

### DIFF
--- a/src/kcas.ml
+++ b/src/kcas.ml
@@ -237,6 +237,8 @@ module Loc = struct
       update_no_alloc backoff loc state @@ fun state before ->
       state.after <- f before
 
+  let modify ?backoff loc f = update ?backoff loc f |> ignore [@@inline]
+
   let exchange ?(backoff = Backoff.default) loc value =
     update_no_alloc backoff loc (new_state value) @@ fun _ _ -> ()
 

--- a/src/kcas.mli
+++ b/src/kcas.mli
@@ -33,6 +33,9 @@ module Loc : sig
       succeeds and then returns the [b] value.  It is safe for the given
       function [f] to raise an exception to abort the update. *)
 
+  val modify : ?backoff:Backoff.t -> 'a t -> ('a -> 'a) -> unit
+  (** [modify r f] is equivalent to [update r f |> ignore]. *)
+
   val exchange : ?backoff:Backoff.t -> 'a t -> 'a -> 'a
   (** [exchange r after] atomically updates the shared memory location [r] to
       the [after] value and returns the current value (before the exchange). *)


### PR DESCRIPTION
This operation, provided by both `Tx` and `Xt` APIs, was missing from the `Loc`.