### PR TITLE
Add `Tx.swap l1 l2` and `Xt.swap ~xt l1 l2`

### DIFF
--- a/src/kcas.ml
+++ b/src/kcas.ml
@@ -380,6 +380,12 @@ module Tx = struct
   let incr loc log = update_as ignore loc (( + ) 1) log
   let decr loc log = update_as ignore loc (( + ) (-1)) log
   let update_as g loc f log = update_as g loc f log
+
+  let swap l1 l2 log =
+    let log, x1 = get l1 log in
+    let log, x2 = exchange l2 x1 log in
+    set l1 x2 log
+
   let return value log = (log, value)
   let delay uxt log = uxt () log
 
@@ -491,6 +497,7 @@ module Xt = struct
   let incr ~xt loc = fetch_and_add ~xt loc 1 |> ignore
   let decr ~xt loc = fetch_and_add ~xt loc (-1) |> ignore
   let update ~xt loc f = update loc (protect xt f) xt
+  let swap ~xt l1 l2 = set ~xt l1 @@ exchange ~xt l2 @@ get ~xt l1
 
   let post_commit ~xt action =
     xt.post_commit <- Action.append action xt.post_commit

--- a/src/kcas.mli
+++ b/src/kcas.mli
@@ -266,6 +266,9 @@ module Tx : sig
   val exchange_as : ('a -> 'b) -> 'a Loc.t -> 'a -> 'b t
   (** [exchange_as g r v] is equivalent to [update r (fun _ -> v) |> map g]. *)
 
+  val swap : 'a Loc.t -> 'a Loc.t -> unit t
+  (** [swap l1 l2] is equivalent to [let* x1 = get l1 in let* x2 = exchange l2 x1 in set l1 x2]. *)
+
   val compare_and_swap : 'a Loc.t -> 'a -> 'a -> 'a t
   (** [compare_and_swap r before after] is equivalent to
 
@@ -431,6 +434,9 @@ module Xt : sig
 
   val exchange : xt:'x t -> 'a Loc.t -> 'a -> 'a
   (** [exchange ~xt r v] is equivalent to [update ~xt r (fun _ -> v)]. *)
+
+  val swap : xt:'x t -> 'a Loc.t -> 'a Loc.t -> unit
+  (** [swap ~xt l1 l2] is equivalent to [set ~xt l1 @@ exchange ~xt l2 @@ get ~xt l1]. *)
 
   val compare_and_swap : xt:'x t -> 'a Loc.t -> 'a -> 'a -> 'a
   (** [compare_and_swap ~xt r before after] is equivalent to


### PR DESCRIPTION
Being able to atomically swap shared memory location contents can be quite useful, because swapping, unlike copying or clearing, for example, is an operation that neither creates, destroys, nor consumes "resources".

This PR adds a `swap` operation to help with that.