### PR TITLE
Avoid unnecessary wakeups in `Loc.exchange`

### DIFF
--- a/src/kcas.ml
+++ b/src/kcas.ml
@@ -341,9 +341,9 @@ let rec update_no_alloc backoff loc state f =
 let rec exchange_no_alloc backoff loc state =
   let state' = fenceless_get (as_atomic loc) in
   let before = eval state' in
-  if
-    before == state.after || Atomic.compare_and_set (as_atomic loc) state' state
-  then resume_awaiters before state'.awaiters
+  if before == state.after then before
+  else if Atomic.compare_and_set (as_atomic loc) state' state then
+    resume_awaiters before state'.awaiters
   else exchange_no_alloc (Backoff.once backoff) loc state
 
 let is_obstruction_free casn =


### PR DESCRIPTION
I noticed that `Loc.exchange` and `Loc.set` would unnecessarily wake up awaiters when the operation would not change the logical value of the location.  Technically this should be considered an optimization rather than a bug fix, but I added a test to check that unnecessary wakeups are avoided in these cases.