### PR TITLE
Allocate locations in descending order

### DIFF
--- a/src/kcas.mli
+++ b/src/kcas.mli
@@ -69,6 +69,10 @@ module Loc : sig
       in rare cases where a location is updated frequently and obstruction-free
       read-only accesses would almost certainly suffer from interference. *)
 
+  val make_array : ?mode:Mode.t -> int -> 'a -> 'a t array
+  (** [make_array n initial] creates an array of [n] new shared memory locations
+      with the [initial] value. *)
+
   val get_mode : 'a t -> Mode.t
   (** [get_mode r] returns the operating mode of the shared memory location
       [r]. *)

--- a/src/kcas_data/accumulator.ml
+++ b/src/kcas_data/accumulator.ml
@@ -11,7 +11,9 @@ let make ?n_way n =
     | None -> n_way_default
     | Some n_way -> n_way |> Int.min n_way_max |> Bits.ceil_pow_2
   in
-  Array.init n_way (fun i -> Loc.make (if i = 0 then n else 0))
+  let a = Loc.make_array ~mode:Mode.lock_free n_way 0 in
+  Loc.set (Array.unsafe_get a 0) n;
+  a
 
 let n_way_of = Array.length
 

--- a/src/kcas_data/queue.ml
+++ b/src/kcas_data/queue.ml
@@ -6,15 +6,15 @@ type 'a t = {
   front : 'a Elems.t Loc.t;
 }
 
-let alloc ~back ~middle ~front =
+let alloc ~front ~middle ~back =
   (* We allocate locations in specific order to make most efficient use of the
      splay-tree based transaction log. *)
-  let back = Loc.make back
+  let front = Loc.make front
   and middle = Loc.make middle
-  and front = Loc.make front in
+  and back = Loc.make back in
   { back; middle; front }
 
-let create () = alloc ~back:Elems.empty ~middle:Elems.empty ~front:Elems.empty
+let create () = alloc ~front:Elems.empty ~middle:Elems.empty ~back:Elems.empty
 
 let copy q =
   let tx ~xt = (Xt.get ~xt q.front, Xt.get ~xt q.middle, Xt.get ~xt q.back) in

--- a/test/benchmark.ml
+++ b/test/benchmark.ml
@@ -16,7 +16,7 @@ let make_kCAS k =
     if k > 0 then
       let a = Loc.make 0 in
       loop (k - 1) (Op.make_cas a 0 1 :: out1) (Op.make_cas a 1 0 :: out2)
-    else (out1, out2)
+    else (List.rev out1, List.rev out2)
   in
 
   loop k [] []


### PR DESCRIPTION
This PR changes the allocation of location ids by `Loc.make` to be done in descending order. This should typically lead to slightly improved performance as it is typical that locations closer to the root of a data structure are allocated before locations further from the root.  So, when a data structure is traversed starting from the root, the resuling splay tree should be right leaning and slightly faster to construct and traverse from left to right.

This PR also adds a `Loc.make_array` function for allocating an array of locations.  The ids of the locations in the array are in ascending order.  This is because iterating over an array in descending order (i.e. a countdown to 0) is often slightly simpler.