### PR TITLE
Reduce test iteration counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1578,7 +1578,7 @@ using a transaction:
 
 ```ocaml
 # with_updater @@ fun () ->
-    for _ = 1 to 10_000 do
+    for _ = 1 to 1_000 do
       let tx ~xt =
         0 = (Xt.get ~xt a + Xt.get ~xt b)
       in
@@ -1600,7 +1600,7 @@ experiment where we abort the transaction in case we observe that the values of
 <!-- $MDX skip -->
 ```ocaml
 # with_updater @@ fun () ->
-    for _ = 1 to 10_000 do
+    for _ = 1 to 1_000 do
       let tx ~xt =
         if 0 <> (Xt.get ~xt a + Xt.get ~xt b) then
           failwith "torn read"

--- a/test/example.ml
+++ b/test/example.ml
@@ -9,4 +9,6 @@ ignore (Kcas.Op.atomically kcas);
 
 (* atomic_1 = 1, atomic_2 = 4 *)
 assert (Kcas.Loc.get atomic_1 = 1);
-assert (Kcas.Loc.get atomic_2 = 4)
+assert (Kcas.Loc.get atomic_2 = 4);
+
+Printf.printf "Example OK!\n%!"

--- a/test/kcas_data/hashtbl_test.ml
+++ b/test/kcas_data/hashtbl_test.ml
@@ -88,3 +88,5 @@ let () =
   Hashtbl.remove t "foo";
   assert (Hashtbl.length t = 1);
   assert (Hashtbl.to_seq t |> List.of_seq |> List.sort compare = [ ("bar", 19) ])
+
+let () = Printf.printf "Test Hashtbl OK!\n%!"

--- a/test/kcas_data/queue_test.ml
+++ b/test/kcas_data/queue_test.ml
@@ -30,4 +30,6 @@ let () =
   assert (Queue.take_opt q = None);
   assert (Queue.take_opt r = Some 101);
   assert (Queue.take_opt r = Some 42);
-  assert (Queue.take_opt r = None)
+  assert (Queue.take_opt r = None);
+
+  Printf.printf "Test Queue OK!\n%!"

--- a/test/kcas_data/stack_test.ml
+++ b/test/kcas_data/stack_test.ml
@@ -18,4 +18,6 @@ let () =
   assert (Stack.length t = 2);
   assert (Stack.pop_opt t = Some 42);
   assert (Stack.pop_opt t = Some 101);
-  assert (Stack.pop_opt t = None)
+  assert (Stack.pop_opt t = None);
+
+  Printf.printf "Test Stack OK!\n%!"

--- a/test/ms_queue_test.ml
+++ b/test/ms_queue_test.ml
@@ -123,7 +123,7 @@ let tail_leak_test n =
   List.init m domain |> List.map Domain.spawn |> List.iter Domain.join
 
 let () =
-  let n = try int_of_string Sys.argv.(1) with _ -> 100_000 in
+  let n = try int_of_string Sys.argv.(1) with _ -> 1_000 in
   write_skew_test n;
   tail_leak_test n;
-  ()
+  Printf.printf "Test MS queue OK!\n%!"

--- a/test/test.ml
+++ b/test/test.ml
@@ -34,7 +34,7 @@ let assert_kcas loc expected_v =
 
 let test_non_linearizable () =
   let barrier = Barrier.make 2
-  and n_iter = 1_000_000
+  and n_iter = 100_000
   and test_finished = ref false in
 
   let a = Loc.make 0 and b = Loc.make 0 in
@@ -208,7 +208,7 @@ let in_place_shuffle array =
   done
 
 let test_presort () =
-  let n_incs = 50_000 and n_domains = 3 and n_locs = 5 in
+  let n_incs = 10_000 and n_domains = 3 and n_locs = 5 in
 
   let barrier = Barrier.make n_domains in
 
@@ -240,7 +240,7 @@ let test_presort () =
 (* *)
 
 let test_presort_and_is_in_log_xt () =
-  let n_incs = 50_000 and n_domains = 3 and n_locs = 12 in
+  let n_incs = 10_000 and n_domains = 3 and n_locs = 12 in
   let n_locs_half = n_locs asr 1 in
 
   let barrier = Barrier.make n_domains in
@@ -482,7 +482,7 @@ let () =
   test_set ();
   test_casn ();
   test_read_casn ();
-  test_stress 1000 10000;
+  test_stress 1_000 1_000;
   test_presort ();
   test_presort_and_is_in_log_xt ();
   test_updates ();
@@ -491,7 +491,8 @@ let () =
   test_blocking ();
   test_no_unnecessary_wakeups ();
   test_validation ();
-  test_xt ()
+  test_xt ();
+  Printf.printf "Test suite OK!\n%!"
 
 (*
   ####

--- a/test/test_overlapping_loc.ml
+++ b/test/test_overlapping_loc.ml
@@ -49,4 +49,6 @@ let test_3 () =
 let _ =
   test_1 ();
   test_2 ();
-  test_3 ()
+  test_3 ();
+
+  Printf.printf "Test overlapping loc OK!\n%!"

--- a/test/threads.ml
+++ b/test/threads.ml
@@ -16,4 +16,6 @@ let () =
 
   Thread.join a_thread;
 
-  assert (Loc.get x + Loc.get y = 42)
+  assert (Loc.get x + Loc.get y = 42);
+
+  Printf.printf "Test threads OK!\n%!"

--- a/test/xt_test.ml
+++ b/test/xt_test.ml
@@ -33,4 +33,6 @@ let () =
   assert (Xt.commit { tx = P.Xt.is_empty p });
 
   Xt.commit { tx = Q.push_front q 101 };
-  assert (not (Xt.commit { tx = Q.is_empty q }))
+  assert (not (Xt.commit { tx = Q.is_empty q }));
+
+  Printf.printf "Test Xt OK!\n%!"


### PR DESCRIPTION
It seems tests sometimes timeout on particular (slower? / older?) CI machines.  This PR reduces the test iteration counts and makes every test print something so that it easy to see on CI.  Even with smaller iteration counts it is likely that the tests will catch the relevant problems and in case of a failure one can then locally increase the counts to reproduce issues.