### PR TITLE
Add mode argument to locations

### DIFF
--- a/src/kcas.mli
+++ b/src/kcas.mli
@@ -59,9 +59,13 @@ module Loc : sig
   type !'a t
   (** Type of shared memory locations. *)
 
-  val make : 'a -> 'a t
+  val make : ?mode:Mode.t -> 'a -> 'a t
   (** [make initial] creates a new shared memory location with the [initial]
       value. *)
+
+  val get_mode : 'a t -> Mode.t
+  (** [get_mode r] returns the operating mode of the shared memory location
+      [r]. *)
 
   val get_id : 'a t -> int
   (** [get_id r] returns the unique id of the shared memory location [r]. *)

--- a/src/kcas.mli
+++ b/src/kcas.mli
@@ -61,7 +61,13 @@ module Loc : sig
 
   val make : ?mode:Mode.t -> 'a -> 'a t
   (** [make initial] creates a new shared memory location with the [initial]
-      value. *)
+      value.
+
+      The optional [mode] argument defaults to {!Mode.obstruction_free}.  If
+      explicitly specified as {!Mode.lock_free}, the location will always be
+      accessed using the lock-free operating mode.  This may improve performance
+      in rare cases where a location is updated frequently and obstruction-free
+      read-only accesses would almost certainly suffer from interference. *)
 
   val get_mode : 'a t -> Mode.t
   (** [get_mode r] returns the operating mode of the shared memory location

--- a/test/dune
+++ b/test/dune
@@ -68,3 +68,9 @@
  (libraries kcas)
  (modules threads)
  (package kcas))
+
+(test
+ (name loc_modes)
+ (libraries kcas barrier)
+ (modules loc_modes)
+ (package kcas))

--- a/test/loc_modes.ml
+++ b/test/loc_modes.ml
@@ -1,0 +1,81 @@
+open Kcas
+
+let loop_count = try int_of_string Sys.argv.(1) with _ -> 1_000
+
+let mode =
+  Some
+    (try
+       if Sys.argv.(2) = "obstruction-free" then Mode.obstruction_free
+       else Mode.lock_free
+     with _ -> Mode.lock_free)
+
+(* Number of shared counters being used to try to cause interference *)
+
+(* Number of private accumulators used for extra work *)
+let n_counters = try int_of_string Sys.argv.(3) with _ -> 2
+let n_accumulators = try int_of_string Sys.argv.(4) with _ -> 2
+let sleep_time = try int_of_string Sys.argv.(5) with _ -> 85
+
+(* Set to true when the accumulator work is done and counter threads may exit.
+   This way we ensure that the counter threads are causing interference for the
+   whole duration of the test. *)
+let exit = ref false
+
+(* Counters are first initialized with a dummy location *)
+let counters =
+  let dummy_location_to_be_replaced = Loc.make 0 in
+  Array.make n_counters dummy_location_to_be_replaced
+
+(* Barrier used to synchronize counter threads and the accumulator thread *)
+let barrier = Barrier.make (n_counters + 1)
+
+let counter_thread i () =
+  (* We allocate actual counter locations within the domain to avoid false
+     sharing *)
+  let counter = Loc.make ?mode 0 in
+  counters.(i) <- counter;
+
+  let tx ~xt = Xt.incr ~xt counter in
+
+  Barrier.await barrier;
+
+  while not !exit do
+    (* Increment the accumulator to cause interference *)
+    Xt.commit { tx };
+
+    (* Delay for a bit.  If we don't delay enough, we can starve the
+       accumulator. *)
+    for _ = 1 to sleep_time do
+      Domain.cpu_relax ()
+    done
+  done
+
+let accumulator_thread () =
+  (* Accumulators allocated in the domain to avoid false sharing *)
+  let accumulators = Array.init n_accumulators (fun _ -> Loc.make 0) in
+
+  let tx ~xt =
+    (* Compute sum of counters - these accesses can be interfered with *)
+    let sum_of_counters =
+      Array.fold_left (fun sum counter -> sum + Xt.get ~xt counter) 0 counters
+    in
+
+    (* And do some other work (updating accumulators) *)
+    Array.iter
+      (fun accumulator ->
+        Xt.fetch_and_add ~xt accumulator sum_of_counters |> ignore)
+      accumulators
+  in
+
+  Barrier.await barrier;
+
+  for _ = 1 to loop_count do
+    Xt.commit { tx }
+  done;
+
+  exit := true
+
+let () =
+  accumulator_thread :: List.init n_counters counter_thread
+  |> List.map Domain.spawn |> List.iter Domain.join;
+  Printf.printf "Test loc modes OK!\n%!"

--- a/test/test.ml
+++ b/test/test.ml
@@ -459,6 +459,15 @@ let test_validation () =
 
 (* *)
 
+let test_mode () =
+  assert (Loc.get_mode (Loc.make ~mode:Mode.lock_free 0) == Mode.lock_free);
+  assert (
+    Loc.get_mode (Loc.make ~mode:Mode.obstruction_free 0)
+    == Mode.obstruction_free);
+  assert (Loc.get_mode (Loc.make 0) == Mode.obstruction_free)
+
+(* *)
+
 type _ _loc_is_injective =
   | Int : int _loc_is_injective
   | Loc : 'a _loc_is_injective -> 'a Loc.t _loc_is_injective
@@ -491,6 +500,7 @@ let () =
   test_blocking ();
   test_no_unnecessary_wakeups ();
   test_validation ();
+  test_mode ();
   test_xt ();
   Printf.printf "Test suite OK!\n%!"
 


### PR DESCRIPTION
This PR is based on PR #35 by @Dashy-Dolphin.

I rsquashed the individual commits:

- Lock-free-mode argument added to Loc
- Lock-free-mode argument added to Loc
- ocamlformat checkl
- ocamlformat checkl
- ocamlformat check
- basic test case added
- basic test case added
- benchmark added
- modified-benchmark using Barrier and encoded loc.mode into loc.id
- benchmark modified
- Lock-free-mode argument added to Loc
- tx_loc_modes.ml modified

into a single commit to simplify rebase against main.

I also made a few minor tweaks so that things work well on CI.