### PR TITLE
Add `Loc.fenceless_get`

### DIFF
--- a/src/kcas.ml
+++ b/src/kcas.ml
@@ -424,6 +424,8 @@ module Loc = struct
   let has_awaiters loc =
     let state = Atomic.get (as_atomic loc) in
     state.awaiters != []
+
+  let fenceless_get loc = eval (fenceless_get (as_atomic loc))
 end
 
 let insert cass loc state =

--- a/src/kcas.mli
+++ b/src/kcas.mli
@@ -125,6 +125,10 @@ module Loc : sig
   val has_awaiters : 'a t -> bool
   (** [has_awaiters r] determines whether the shared memory location [r] has
       awaiters. *)
+
+  val fenceless_get : 'a t -> 'a
+  (** [fenceless_get r] is like [get r] except that [fenceless_get]s may be
+      reordered. *)
 end
 
 (** {1 Manipulating multiple locations atomically}

--- a/src/kcas_data/dllist.ml
+++ b/src/kcas_data/dllist.ml
@@ -31,7 +31,7 @@ module Xt = struct
 
   let add_node_l ~xt node list =
     let next = Xt.get ~xt list.next in
-    assert (Loc.get node.node_prev == list);
+    assert (Loc.fenceless_get node.node_prev == list);
     Loc.set node.node_next next;
     Xt.set ~xt list.next (as_list node);
     Xt.set ~xt next.prev (as_list node);
@@ -47,7 +47,7 @@ module Xt = struct
   let add_node_r ~xt node list =
     let prev = Xt.get ~xt list.prev in
     Loc.set node.node_prev prev;
-    assert (Loc.get node.node_next == list);
+    assert (Loc.fenceless_get node.node_next == list);
     Xt.set ~xt list.prev (as_list node);
     Xt.set ~xt prev.next (as_list node);
     node


### PR DESCRIPTION
This PR adds a `Loc.fenceless_get` operation, which is omitted from the public documentation.  The operation is safe, but fenceless get operations may be reordered by both the compiler and the CPU, which means that uses of fenceless get require some care as it may essentially allow non-serializable observations of shared memory locations.  Fenceless get operations can be used, for example, when a sequence of dependent loads are made.  Because use requires some extra care, the operation is omitted from the official documentation.