### PR TITLE
Nested transactions

### DIFF
--- a/src/kcas_data/hashtbl.ml
+++ b/src/kcas_data/hashtbl.ml
@@ -203,7 +203,7 @@ module Xt = struct
             let initial_state = Array.length old_buckets in
             while true do
               (* If state is modified outside our expensive tx would fail. *)
-              Retry.unless (Loc.fenceless_get state = initial_state);
+              if Loc.fenceless_get state != initial_state then Retry.invalid ();
               rehash_a_few_buckets ~xt
             done
           else
@@ -217,7 +217,7 @@ module Xt = struct
         assert (not must_be_done_in_this_tx);
         let buckets = Xt.get ~xt t.buckets in
         (* Check state to ensure that buckets have not been updated. *)
-        Retry.unless (0 <= Loc.fenceless_get state);
+        if Loc.fenceless_get state < 0 then Retry.invalid ();
         let snapshot =
           get_or_alloc snapshot @@ fun () ->
           Array.make (Array.length buckets) []
@@ -239,7 +239,7 @@ module Xt = struct
         assert (not must_be_done_in_this_tx);
         let old_buckets = Xt.get ~xt t.buckets in
         (* Check state to ensure that buckets have not been updated. *)
-        Retry.unless (0 <= Loc.fenceless_get state);
+        if Loc.fenceless_get state < 0 then Retry.invalid ();
         let new_capacity = Array.length old_buckets in
         let new_buckets =
           get_or_alloc new_buckets @@ fun () -> Loc.make_array new_capacity []


### PR DESCRIPTION
This PR adds low level support for nested (conditional) transactions.

The idea is that a snapshot of a transaction log can be taken and later the transaction log can be rolled back to discard any changes made after the snapshot was taken.  This allows transactions to record tentative changes to locations and then later perform a rollback.  This also allows transaction implementations to scope such rollbacks as desired.

Some other STM implementations make such rollbacks implicitly.  The reasoning for not making rollbacks implicit is based on the following:

1. In many cases rollback is unnecessary.   For example, `Queue.Xt.take_blocking` does not logically mutate the queue in case it signals retry and that applies to many similar operations.
2. In some cases rollback is not only unnecessary, but might also be undesirable as a transaction might record benign changes that "move things forward" without changing the logical state of abstractions.  In other words, the scoping of ideal rollback depends on the internals of transactions.
3. Performing a rollback is potentially linear time `O(n)` in the number of accessed locations and relatively expensive.

The disadvantage of not making rollbacks implicit is, of course, that it potentially makes the programming model more difficult.