### PR TITLE
Fix to allow retry from within `Xt.update` and `Xt.modify`

### DIFF
--- a/test/kcas/test.ml
+++ b/test/kcas/test.ml
@@ -328,7 +328,13 @@ let test_backoff () =
 let test_blocking () =
   let state = Loc.make `Spawned in
   let await state' =
-    Loc.get_as (fun state -> Retry.unless (state == state')) state
+    (* Intentionally test that [Xt.modify] allows retry. *)
+    let tx ~xt =
+      Xt.modify ~xt state @@ fun state ->
+      Retry.unless (state == state');
+      state
+    in
+    Xt.commit { tx }
   in
 
   let a = Loc.make 0 and bs = Array.init 10 @@ fun _ -> Loc.make 0 in


### PR DESCRIPTION
I realized that raising `Retry.Later` from within `Xt.update` and `Xt.modify` did not always allow one to wait for changes to the accessed location.  I considered whether it would make sense to consider that illegal, but given that `Loc.update` and `Loc.modify` explicitly allow it, I think it is best to support it.