### PR TITLE
Change `Hashtbl` config to be part of the transactional data

### DIFF
--- a/src/kcas_data/hashtbl_intf.ml
+++ b/src/kcas_data/hashtbl_intf.ml
@@ -15,6 +15,9 @@ module type Ops = sig
   val clear : ('x, ('k, 'v) t -> unit) fn
   (** [clear] is a synonym for {!reset}. *)
 
+  val swap : ('x, ('k, 'v) t -> ('k, 'v) t -> unit) fn
+  (** [swap t1 t2] exchanges the contents of the hash tables [t1] and [t2]. *)
+
   val remove : ('x, ('k, 'v) t -> 'k -> unit) fn
   (** [remove t k] removes the most recent existing binding of key [k], if any,
       from the hash table [t] thereby revealing the earlier binding of [k], if

--- a/test/kcas_data/hashtbl_test.ml
+++ b/test/kcas_data/hashtbl_test.ml
@@ -55,10 +55,12 @@ let () =
   assert (
     Hashtbl.to_seq t |> List.of_seq = [ ("key", 3); ("key", 2); ("key", 1) ]);
   let u = Hashtbl.to_seq t |> Hashtbl.of_seq in
-  assert (Hashtbl.find u "key" = 1);
-  assert (Hashtbl.find t "key" = 3);
-  Hashtbl.filter_map_inplace (fun _ v -> if v = 1 then None else Some (-v)) t;
-  assert (Hashtbl.find_all t "key" = [ -3; -2 ]);
+  Hashtbl.swap t u;
+  assert (Hashtbl.find t "key" = 1);
+  assert (Hashtbl.find u "key" = 3);
+  Hashtbl.filter_map_inplace (fun _ v -> if v = 1 then None else Some (-v)) u;
+  assert (Hashtbl.find_all u "key" = [ -3; -2 ]);
+  Hashtbl.swap u t;
   assert (Hashtbl.length t = 2);
   (match
      Hashtbl.filter_map_inplace


### PR DESCRIPTION
This changes the `Hashtbl` implementation such that the configuration of the hash table is inside a shared memory location.  This has a number of potential benefits:
- For mutation operations it means one fewer shared memory location is accessed, which should improve performance in some workloads.
- It makes it possible to implement a `swap` operation.