### PR TITLE
Avoid false sharing in `Hashtbl` benchmark

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -16,5 +16,6 @@
  (synopsis "Compositional lock-free data structures and primitives for communication and synchronization")
  (depends
   (kcas (= :version))
-  (mdx (and (>= 1.10.0) :with-test))))
+  (mdx (and (>= 1.10.0) :with-test))
+  (multicore-magic (and (>= 1.0.0) :with-test))))
 (using mdx 0.2)

--- a/kcas_data.opam
+++ b/kcas_data.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "3.3"}
   "kcas" {= version}
   "mdx" {>= "1.10.0" & with-test}
+  "multicore-magic" {>= "1.0.0" & with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/test/kcas_data/dune
+++ b/test/kcas_data/dune
@@ -7,7 +7,7 @@
 (test
  (name hashtbl_bench)
  (modules hashtbl_bench)
- (libraries kcas kcas_data unix)
+ (libraries kcas kcas_data unix multicore-magic)
  (package kcas_data))
 
 (test

--- a/test/kcas_data/hashtbl_bench.ml
+++ b/test/kcas_data/hashtbl_bench.ml
@@ -7,7 +7,10 @@ module Int = struct
 end
 
 let bench ~n_domains ~n_ops ~n_keys ~percent_read =
-  let t = Hashtbl.create ~hashed_type:(module Int) () in
+  let t =
+    Hashtbl.create ~hashed_type:(module Int) ()
+    |> Multicore_magic.copy_as_padded
+  in
 
   for i = 0 to n_keys - 1 do
     Hashtbl.replace t i i
@@ -15,7 +18,7 @@ let bench ~n_domains ~n_ops ~n_keys ~percent_read =
 
   let barrier = Atomic.make n_domains in
 
-  let n_ops_todo = Atomic.make n_ops in
+  let n_ops_todo = Atomic.make n_ops |> Multicore_magic.copy_as_padded in
   let rec alloc_ops () =
     let n = Atomic.get n_ops_todo in
     if n = 0 then 0


### PR DESCRIPTION
I noticed that the `Hashtbl` benchmark was potentially suffering from false sharing.  This PR adds some multicore magic to avoid the false sharing.  In the future when aligned atomics land we can probably do something better.