### PR TITLE
Add `Dllist.move_l node list` and `Dllist.move_r node list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,12 +853,10 @@ an operation to change the capacity of the cache.
 
 ### Programming with primitive operations
 
-The [`Op`](https://ocaml-multicore.github.io/kcas/doc/kcas/Kcas/Op/index.html)
-module is probably most suitable when using **kcas** as a means to design and
-implement new lock-free algorithms.
-
-To program with primitive operations one simply makes a list of CAS operations
-using
+In addition to the transactional interface, **kcas** also provides the
+[`Op`](https://ocaml-multicore.github.io/kcas/doc/kcas/Kcas/Op/index.html)
+interface for performing a list of primitive operations. To program with
+primitive operations one simply makes a list of CAS operations using
 [`make_cas`](https://ocaml-multicore.github.io/kcas/doc/kcas/Kcas/Op/index.html#val-make_cas)
 and then attempts them using
 [`atomically`](https://ocaml-multicore.github.io/kcas/doc/kcas/Kcas/Op/index.html#val-atomically).

--- a/src/kcas_data/dllist.ml
+++ b/src/kcas_data/dllist.ml
@@ -59,6 +59,28 @@ module Xt = struct
     Xt.set ~xt prev.next (as_list node);
     node
 
+  let move_l ~xt node list =
+    let node = as_list node in
+    let list_next = Xt.exchange ~xt list.next node in
+    if list_next != node then (
+      let node_prev = Xt.exchange ~xt node.prev list in
+      let node_next = Xt.exchange ~xt node.next list_next in
+      if node_prev != node then (
+        Xt.set ~xt node_prev.next node_next;
+        Xt.set ~xt node_next.prev node_prev);
+      Xt.set ~xt list_next.prev node)
+
+  let move_r ~xt node list =
+    let node = as_list node in
+    let list_prev = Xt.exchange ~xt list.prev node in
+    if list_prev != node then (
+      let node_next = Xt.exchange ~xt node.next list in
+      let node_prev = Xt.exchange ~xt node.prev list_prev in
+      if node_next != node then (
+        Xt.set ~xt node_prev.next node_next;
+        Xt.set ~xt node_next.prev node_prev);
+      Xt.set ~xt list_prev.next node)
+
   let take_opt_l ~xt list =
     let next = Xt.get ~xt list.next in
     if next == list then None
@@ -140,6 +162,8 @@ let add_r value list =
   let node = create_node ~prev:list ~next:list value in
   Kcas.Xt.commit { tx = Xt.add_node_r node list }
 
+let move_l node list = Kcas.Xt.commit { tx = Xt.move_l node list }
+let move_r node list = Kcas.Xt.commit { tx = Xt.move_r node list }
 let take_opt_l list = Kcas.Xt.commit { tx = Xt.take_opt_l list }
 let take_opt_r list = Kcas.Xt.commit { tx = Xt.take_opt_r list }
 let take_blocking_l list = Kcas.Xt.commit { tx = Xt.take_blocking_l list }

--- a/src/kcas_data/dllist_intf.ml
+++ b/src/kcas_data/dllist_intf.ml
@@ -7,6 +7,14 @@ module type Ops = sig
   (** [remove n] removes the node [n] from the doubly-linked list it is part of.
       [remove] is idempotent. *)
 
+  val move_l : ('x, 'a node -> 'a t -> unit) fn
+  (** [move_to_l n l] removes the node [n] from the doubly linked list it is
+      part of and then add it to the left of list [l]. *)
+
+  val move_r : ('x, 'a node -> 'a t -> unit) fn
+  (** [move_to_r n l] removes the node [n] from the doubly linked list it is
+      part of and then add it to the right of list [l]. *)
+
   val is_empty : ('x, 'a t -> bool) fn
   (** [is_empty l] determines whether the doubly-linked list [l] is empty or
       not. *)

--- a/test/kcas_data/dllist_test.ml
+++ b/test/kcas_data/dllist_test.ml
@@ -38,3 +38,28 @@ let () =
   Dllist.add_l 3 l |> ignore;
   Dllist.add_r 4 l |> ignore;
   assert (take_as_list Dllist.take_opt_l l = [ 3; 1; 4 ])
+
+let () =
+  let t1 = Dllist.create () in
+  let n1 = Dllist.add_l 5.3 t1 in
+  Dllist.move_l n1 t1;
+  assert (Dllist.to_list_l t1 = [ 5.3 ]);
+  Dllist.move_r n1 t1;
+  assert (Dllist.to_list_l t1 = [ 5.3 ]);
+  let n2 = Dllist.add_l 5.2 t1 in
+  assert (Dllist.to_list_l t1 = [ 5.2; 5.3 ]);
+  Dllist.move_r n2 t1;
+  assert (Dllist.to_list_l t1 = [ 5.3; 5.2 ]);
+  Dllist.move_l n2 t1;
+  assert (Dllist.to_list_l t1 = [ 5.2; 5.3 ]);
+  let t2 = Dllist.create () in
+  Dllist.move_l n1 t2;
+  assert (Dllist.to_list_l t1 = [ 5.2 ]);
+  assert (Dllist.to_list_l t2 = [ 5.3 ]);
+  Dllist.move_r n2 t2;
+  assert (Dllist.to_list_l t2 = [ 5.3; 5.2 ]);
+  Dllist.move_l n1 t1;
+  assert (Dllist.to_list_l t2 = [ 5.2 ]);
+  assert (Dllist.to_list_l t1 = [ 5.3 ])
+
+let () = Printf.printf "Test Dllist OK!\n%!"


### PR DESCRIPTION
This PR adds `move_l` and `move_r` operations to the doubly-linked list allowing individual nodes to be moved to the left or right end of some list.

This PR also starts a new section in the README on "Programming with transactional data structures" and adds an example of a LRU cache implemented using `Hashtbl` and `Dllist`.