### PR TITLE
Fix single location no-op updates to be strictly serializable and fix `Loc.compare_and_set` to have strong semantics

### DIFF
--- a/src/kcas/kcas.mli
+++ b/src/kcas/kcas.mli
@@ -141,6 +141,14 @@ module Loc : sig
   val fenceless_get : 'a t -> 'a
   (** [fenceless_get r] is like [get r] except that [fenceless_get]s may be
       reordered. *)
+
+  val fenceless_update : ?backoff:Backoff.t -> 'a t -> ('a -> 'a) -> 'a
+  (** [fenceless_update r f] is like [update r f] except that in case [f x == x]
+      the update may be reordered. *)
+
+  val fenceless_modify : ?backoff:Backoff.t -> 'a t -> ('a -> 'a) -> unit
+  (** [fenceless_modify r f] is like [modify r f] except that in case [f x == x]
+      the modify may be reordered. *)
 end
 
 (** {1 Manipulating multiple locations atomically}

--- a/src/kcas_data/hashtbl.ml
+++ b/src/kcas_data/hashtbl.ml
@@ -353,11 +353,13 @@ end
 
 let find_opt t k =
   let t = Loc.get t in
+  (* Fenceless is safe as we have a fence above. *)
   t.buckets |> bucket_of t.hash k |> Loc.fenceless_get
   |> Assoc.find_opt t.equal k
 
 let find_all t k =
   let t = Loc.get t in
+  (* Fenceless is safe as we have a fence above. *)
   t.buckets |> bucket_of t.hash k |> Loc.fenceless_get
   |> Assoc.find_all t.equal k
 
@@ -365,6 +367,7 @@ let find t k = match find_opt t k with None -> raise Not_found | Some v -> v
 
 let mem t k =
   let t = Loc.get t in
+  (* Fenceless is safe as we have a fence above. *)
   t.buckets |> bucket_of t.hash k |> Loc.fenceless_get |> Assoc.mem t.equal k
 
 let clear t = Kcas.Xt.commit { tx = Xt.clear t }
@@ -388,6 +391,7 @@ let snapshot ?length ?record t =
   in
   Kcas.Xt.commit { tx };
   Kcas.Xt.commit { tx = Xt.perform_pending t } |> ignore;
+  (* Fenceless is safe as commit above has fences. *)
   Loc.fenceless_get snapshot
 
 let to_seq t =
@@ -463,6 +467,7 @@ let filter_map_inplace fn t =
   in
   Kcas.Xt.commit { tx };
   Kcas.Xt.commit { tx = Xt.perform_pending t } |> ignore;
+  (* Fenceless is safe as commit above has fences. *)
   match Loc.fenceless_get raised with Done -> () | exn -> raise exn
 
 let stats t =

--- a/src/kcas_data/mvar.ml
+++ b/src/kcas_data/mvar.ml
@@ -25,12 +25,18 @@ module Xt = struct
 end
 
 let is_empty mv = Magic_option.is_none (Loc.get mv)
-let put mv value = Loc.modify mv (Magic_option.put_or_retry value)
+
+let put mv value =
+  (* Fenceless is safe as we always update. *)
+  Loc.fenceless_modify mv (Magic_option.put_or_retry value)
 
 let try_put mv value =
   Loc.compare_and_set mv Magic_option.none (Magic_option.some value)
 
-let take mv = Magic_option.get_unsafe (Loc.update mv Magic_option.take_or_retry)
+let take mv =
+  (* Fenceless is safe as we always update. *)
+  Magic_option.get_unsafe (Loc.fenceless_update mv Magic_option.take_or_retry)
+
 let take_opt mv = Magic_option.to_option (Loc.exchange mv Magic_option.none)
 let peek mv = Loc.get_as Magic_option.get_or_retry mv
 let peek_opt mv = Magic_option.to_option (Loc.get mv)

--- a/src/kcas_data/stack.ml
+++ b/src/kcas_data/stack.ml
@@ -25,10 +25,18 @@ end
 
 let length s = Loc.get s |> Elems.length
 let is_empty s = Loc.get s == Elems.empty
-let push x s = Loc.modify s @@ Elems.cons x
+
+let push x s =
+  (* Fenceless is safe as we always update. *)
+  Loc.fenceless_modify s @@ Elems.cons x
+
 let pop_opt s = Loc.update s Elems.tl_safe |> Elems.hd_opt
 let pop_all s = Loc.exchange s Elems.empty |> Elems.to_seq
-let pop_blocking s = Loc.update s Elems.tl_or_retry |> Elems.hd_unsafe
+
+let pop_blocking s =
+  (* Fenceless is safe as we always update. *)
+  Loc.fenceless_update s Elems.tl_or_retry |> Elems.hd_unsafe
+
 let top_opt s = Loc.get s |> Elems.hd_opt
 let top_blocking s = Loc.get_as Elems.hd_or_retry s
 let clear s = Loc.set s Elems.empty


### PR DESCRIPTION
I realized that due to a combination of two optimizations

1. use of a `fenceless_get` operation to get the state and value of a location, and

2. avoidance of updating a location in case the new value is the same as the old value,

there were update operations that didn't have the correct strictly serializable semantics in the case the update would result in the same value as the old (i.e. a no-op update) as in those cases the serializing fences would be completely avoided.  This PR fixes those cases.

I added `Loc.fenceless_update` and `Loc.fenceless_modify` as undocumented functions for experts.  The reason for adding those is that they are important for best performance on ARM and it is relatively easy to describe cases when they are safe to use. In particular, those are safe to use as long as `f x != x` always for the function `f` passed to them.  Additionally, they are safe when, in the case of `f x == x`, some other approach is used to ensure strict serializabilty.  These cases are common enough (in the implementation of stacks and queues, for example) to warrant the special case functions.

I also realized that `Loc.compare_and_set` did not have the strong semantics meaning that a `Loc.compare_and_set` could fail even when the location had the expected value.  The state of a location may be updated, for example, due to adding or removing waiters and that could cause `Loc.compare_and_set` to fail spuriously.  (The current algorithm mostly avoids changing location state on no-op updates to avoid causing unnecessary wakeups of waiters.)

It seems that the weak `compare_and_set` semantic has been in the library for a long time.  Consider the implementation from [0.1.6](https://github.com/ocaml-multicore/kcas/blob/a3064e412188e6ee6fb770abc6b5cb83591ce1ea/src/kcas.ml#L50-L54):

```ocaml
let commit (CAS (r, expect, update)) =
  let curr_value = Atomic.get r.content in
  st_eq curr_value expect && Atomic.compare_and_set r.content curr_value update

let cas r e u = commit (mk_cas r e u)
```

In the above `expect` and `update` are tagged.  This means that a concurrent no-op update of the location `r` just before the `Atomic.compare_and_set` could cause it to fail spuriously.

One could argue that the weak semantic is just fine and potentially better.  However, that would make `Loc.compare_and_set` subtly different from `Atomic.compare_and_set`.  There should preferably be a different name for a weak version of `compare_and_set`.
