### PR TITLE
Timeouts

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,6 +11,7 @@
  (depends 
   (ocaml (>= 5.0))
   (domain-local-await (>= 0.2.0))
+  (domain-local-timeout (>= 0.1.0))
   (alcotest (and (>= 1.7.0) :with-test))
   (mdx (and (>= 1.10.0) :with-test))))
 (package (name kcas_data)

--- a/kcas.opam
+++ b/kcas.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "3.3"}
   "ocaml" {>= "5.0"}
   "domain-local-await" {>= "0.2.0"}
+  "domain-local-timeout" {>= "0.1.0"}
   "alcotest" {>= "1.7.0" & with-test}
   "mdx" {>= "1.10.0" & with-test}
   "odoc" {with-doc}

--- a/src/kcas/dune
+++ b/src/kcas/dune
@@ -1,4 +1,4 @@
 (library
  (name kcas)
  (public_name kcas)
- (libraries domain-local-await))
+ (libraries domain-local-await domain-local-timeout))

--- a/test/kcas/dune
+++ b/test/kcas/dune
@@ -5,7 +5,7 @@
 
 (test
  (name test)
- (libraries kcas barrier unix alcotest)
+ (libraries kcas barrier threads alcotest)
  (modules test)
  (package kcas))
 


### PR DESCRIPTION
Based on a scheduler independent [domain-local-timeout](https://github.com/ocaml-multicore/domain-local-timeout#readme) mechanism for setting timeouts, i.e. callback to be called after specified amount of time, this PR adds an optional `timeoutf` argument to specify a timeout in seconds for potentially blocking operations.