### PR TITLE
Change/Fix to also snapshot and rollback post commit actions

### DIFF
--- a/src/kcas/kcas.ml
+++ b/src/kcas/kcas.ml
@@ -727,10 +727,13 @@ module Xt = struct
               and gt = rollback casn gt_mark gt in
               CASN { loc; state; lt; gt; awaiters = [] })
 
-  type 'x snap = cass
+  type 'x snap = cass * Action.t
 
-  let snapshot ~xt = xt.cass
-  let rollback ~xt snap = xt.cass <- rollback xt.casn snap xt.cass
+  let snapshot ~xt = (xt.cass, xt.post_commit)
+
+  let rollback ~xt (snap, post_commit) =
+    xt.cass <- rollback xt.casn snap xt.cass;
+    xt.post_commit <- post_commit
 
   let rec first ~xt tx = function
     | [] -> tx ~xt


### PR DESCRIPTION
This PR changes the `Xt.snapshot` and `Xt.rollback` operations to also include post commit actions registered with `Xt.post_commit`.  The post commit actions were forgotten in the initial implementation of snapshot-rollback, but upon thinking about this, it doesn't make sense to not include the post commit actions in rollbacks.