### PR TITLE
Use alcotest to get prettier test outputs

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,11 +11,13 @@
  (depends 
   (ocaml (>= 5.0))
   (domain-local-await (>= 0.2.0))
+  (alcotest (and (>= 1.7.0) :with-test))
   (mdx (and (>= 1.10.0) :with-test))))
 (package (name kcas_data)
  (synopsis "Compositional lock-free data structures and primitives for communication and synchronization")
  (depends
   (kcas (= :version))
+  (alcotest (and (>= 1.7.0) :with-test))
   (mdx (and (>= 1.10.0) :with-test))
   (multicore-magic (and (>= 1.0.0) :with-test))))
 (using mdx 0.2)

--- a/kcas.opam
+++ b/kcas.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "3.3"}
   "ocaml" {>= "5.0"}
   "domain-local-await" {>= "0.2.0"}
+  "alcotest" {>= "1.7.0" & with-test}
   "mdx" {>= "1.10.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/kcas_data.opam
+++ b/kcas_data.opam
@@ -10,6 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
 depends: [
   "dune" {>= "3.3"}
   "kcas" {= version}
+  "alcotest" {>= "1.7.0" & with-test}
   "mdx" {>= "1.10.0" & with-test}
   "multicore-magic" {>= "1.0.0" & with-test}
   "odoc" {with-doc}

--- a/test/kcas/dune
+++ b/test/kcas/dune
@@ -5,13 +5,13 @@
 
 (test
  (name test)
- (libraries kcas barrier unix)
+ (libraries kcas barrier unix alcotest)
  (modules test)
  (package kcas))
 
 (test
  (name test_overlapping_loc)
- (libraries kcas)
+ (libraries kcas alcotest)
  (modules test_overlapping_loc)
  (package kcas))
 
@@ -35,7 +35,7 @@
 
 (test
  (name ms_queue_test)
- (libraries kcas)
+ (libraries kcas alcotest)
  (modules ms_queue_test)
  (package kcas))
 
@@ -47,7 +47,7 @@
 
 (test
  (name threads)
- (libraries kcas threads)
+ (libraries kcas threads alcotest)
  (modules threads)
  (package kcas))
 

--- a/test/kcas/loc_modes.ml
+++ b/test/kcas/loc_modes.ml
@@ -78,4 +78,4 @@ let accumulator_thread () =
 let () =
   accumulator_thread :: List.init n_counters counter_thread
   |> List.map Domain.spawn |> List.iter Domain.join;
-  Printf.printf "Test loc modes OK!\n%!"
+  Printf.printf "Loc modes OK!\n%!"

--- a/test/kcas/ms_queue_test.ml
+++ b/test/kcas/ms_queue_test.ml
@@ -124,6 +124,10 @@ let tail_leak_test n =
 
 let () =
   let n = try int_of_string Sys.argv.(1) with _ -> 1_000 in
-  write_skew_test n;
-  tail_leak_test n;
-  Printf.printf "Test MS queue OK!\n%!"
+  Alcotest.run "MS queue"
+    [
+      ( "write skew",
+        [ Alcotest.test_case "" `Quick (fun () -> write_skew_test n) ] );
+      ( "tail leak",
+        [ Alcotest.test_case "" `Quick (fun () -> tail_leak_test n) ] );
+    ]

--- a/test/kcas/test.ml
+++ b/test/kcas/test.ml
@@ -592,22 +592,30 @@ let test_xt () =
   assert (Loc.get rx = Loc.get ry)
 
 let () =
-  test_non_linearizable ();
-  test_set ();
-  test_casn ();
-  test_read_casn ();
-  test_stress 1_000 1_000;
-  test_presort ();
-  test_presort_and_is_in_log_xt ();
-  test_updates ();
-  test_post_commit ();
-  test_backoff ();
-  test_blocking ();
-  test_no_unnecessary_wakeups ();
-  test_periodic_validation ();
-  test_explicit_validation ();
-  test_rollback ();
-  test_call ();
-  test_mode ();
-  test_xt ();
-  Printf.printf "Test suite OK!\n%!"
+  Alcotest.run "kcas"
+    [
+      ( "non linearizable",
+        [ Alcotest.test_case "" `Quick test_non_linearizable ] );
+      ("set", [ Alcotest.test_case "" `Quick test_set ]);
+      ("casn", [ Alcotest.test_case "" `Quick test_casn ]);
+      ("read casn", [ Alcotest.test_case "" `Quick test_read_casn ]);
+      ( "stress",
+        [ Alcotest.test_case "" `Quick (fun () -> test_stress 1_000 1_0) ] );
+      ("presort", [ Alcotest.test_case "" `Quick test_presort ]);
+      ( "is_in_log",
+        [ Alcotest.test_case "" `Quick test_presort_and_is_in_log_xt ] );
+      ("updates", [ Alcotest.test_case "" `Quick test_updates ]);
+      ("post commit", [ Alcotest.test_case "" `Quick test_post_commit ]);
+      ("backoff", [ Alcotest.test_case "" `Quick test_backoff ]);
+      ("blocking", [ Alcotest.test_case "" `Quick test_blocking ]);
+      ( "no unnecessary wakeups",
+        [ Alcotest.test_case "" `Quick test_no_unnecessary_wakeups ] );
+      ( "pediodic validation",
+        [ Alcotest.test_case "" `Quick test_periodic_validation ] );
+      ( "explicit validation",
+        [ Alcotest.test_case "" `Quick test_explicit_validation ] );
+      ("rollback", [ Alcotest.test_case "" `Quick test_rollback ]);
+      ("call", [ Alcotest.test_case "" `Quick test_call ]);
+      ("mode", [ Alcotest.test_case "" `Quick test_mode ]);
+      ("xt", [ Alcotest.test_case "" `Quick test_xt ]);
+    ]

--- a/test/kcas/test_overlapping_loc.ml
+++ b/test/kcas/test_overlapping_loc.ml
@@ -1,7 +1,7 @@
 module Loc = Kcas.Loc
 module Op = Kcas.Op
 
-let test_1 () =
+let conflicting_overlap () =
   (* [cas_2] acts on the same location as [cas_1]
      and has conflicting values. kCAS should be failing.
   *)
@@ -13,7 +13,7 @@ let test_1 () =
   | exception _ -> ()
   | _ -> assert false
 
-let test_2 () =
+let conflicting_duplicate () =
   (* [cas_2] acts on the same location as [cas_1]
      and has conflicting values. kCAS should fail.
 
@@ -30,7 +30,7 @@ let test_2 () =
   | exception _ -> ()
   | _ -> assert false
 
-let test_3 () =
+let meldable_overlap () =
   (* [cas_2] acts on the same location as [cas_1].
      This is not something that we can handle in the
      general case, but in this particular one,
@@ -47,8 +47,11 @@ let test_3 () =
   | _ -> assert false
 
 let _ =
-  test_1 ();
-  test_2 ();
-  test_3 ();
-
-  Printf.printf "Test overlapping loc OK!\n%!"
+  Alcotest.run "overlapping loc"
+    [
+      ( "conflicting overlap",
+        [ Alcotest.test_case "" `Quick conflicting_overlap ] );
+      ( "conflicting duplicate",
+        [ Alcotest.test_case "" `Quick conflicting_duplicate ] );
+      ("meldable overlap", [ Alcotest.test_case "" `Quick meldable_overlap ]);
+    ]

--- a/test/kcas/threads.ml
+++ b/test/kcas/threads.ml
@@ -1,6 +1,6 @@
 open Kcas
 
-let () =
+let await_between_threads () =
   let x = Loc.make 0 in
   let y = Loc.make 0 in
 
@@ -16,6 +16,11 @@ let () =
 
   Thread.join a_thread;
 
-  assert (Loc.get x + Loc.get y = 42);
+  assert (Loc.get x + Loc.get y = 42)
 
-  Printf.printf "Test threads OK!\n%!"
+let () =
+  Alcotest.run "threads"
+    [
+      ( "await between threads",
+        [ Alcotest.test_case "" `Quick await_between_threads ] );
+    ]

--- a/test/kcas_data/dllist_test.ml
+++ b/test/kcas_data/dllist_test.ml
@@ -3,7 +3,7 @@ open Kcas_data
 let[@tail_mod_cons] rec take_as_list take l =
   match take l with None -> [] | Some x -> x :: take_as_list take l
 
-let () =
+let basics () =
   let t1 = Dllist.create () in
   let t1' = Dllist.take_all t1 in
   assert (Dllist.to_list_r t1 = [] && Dllist.to_list_l t1' = []);
@@ -32,14 +32,14 @@ let () =
   assert (Dllist.take_opt_l t2 = None);
   assert (take_as_list Dllist.take_opt_r t1 = [ 4; 3; 2; 1 ])
 
-let () =
+let add () =
   let l = Dllist.create () in
   Dllist.add_l 1 l |> ignore;
   Dllist.add_l 3 l |> ignore;
   Dllist.add_r 4 l |> ignore;
   assert (take_as_list Dllist.take_opt_l l = [ 3; 1; 4 ])
 
-let () =
+let move () =
   let t1 = Dllist.create () in
   let n1 = Dllist.add_l 5.3 t1 in
   Dllist.move_l n1 t1;
@@ -62,4 +62,10 @@ let () =
   assert (Dllist.to_list_l t2 = [ 5.2 ]);
   assert (Dllist.to_list_l t1 = [ 5.3 ])
 
-let () = Printf.printf "Test Dllist OK!\n%!"
+let () =
+  Alcotest.run "Dllist"
+    [
+      ("basics", [ Alcotest.test_case "" `Quick basics ]);
+      ("add", [ Alcotest.test_case "" `Quick add ]);
+      ("move", [ Alcotest.test_case "" `Quick move ]);
+    ]

--- a/test/kcas_data/dune
+++ b/test/kcas_data/dune
@@ -1,7 +1,7 @@
 (test
  (name dllist_test)
  (modules dllist_test)
- (libraries kcas kcas_data)
+ (libraries kcas kcas_data alcotest)
  (package kcas_data))
 
 (test
@@ -13,29 +13,29 @@
 (test
  (name hashtbl_test)
  (modules hashtbl_test)
- (libraries kcas kcas_data)
+ (libraries kcas kcas_data alcotest)
  (package kcas_data))
 
 (test
  (name mvar_test)
  (modules mvar_test)
- (libraries kcas kcas_data)
+ (libraries kcas kcas_data alcotest)
  (package kcas_data))
 
 (test
  (name queue_test)
  (modules queue_test)
- (libraries kcas kcas_data)
+ (libraries kcas kcas_data alcotest)
  (package kcas_data))
 
 (test
  (name stack_test)
  (modules stack_test)
- (libraries kcas kcas_data)
+ (libraries kcas kcas_data alcotest)
  (package kcas_data))
 
 (test
  (name xt_test)
  (modules xt_test xt_linked_queue xt_stack)
- (libraries kcas kcas_data)
+ (libraries kcas kcas_data alcotest)
  (package kcas_data))

--- a/test/kcas_data/hashtbl_test.ml
+++ b/test/kcas_data/hashtbl_test.ml
@@ -1,7 +1,7 @@
 open Kcas
 open Kcas_data
 
-let () =
+let replace_and_remove () =
   let t = Hashtbl.create () in
   let n = try int_of_string Sys.argv.(1) with _ -> 10_000 in
   for i = 1 to n do
@@ -17,7 +17,7 @@ let () =
   done;
   assert (Hashtbl.length t = 0)
 
-let () =
+let large_tx () =
   let t = Hashtbl.create () in
   let n = 1_000 in
   let tx ~xt =
@@ -34,7 +34,7 @@ let () =
   in
   Xt.commit { tx }
 
-let () =
+let large_ops () =
   let t = Hashtbl.create () in
   Hashtbl.add t "key" 1;
   Hashtbl.add t "key" 2;
@@ -72,7 +72,7 @@ let () =
   assert (Hashtbl.find_all t "key" = [ -3; -2 ]);
   assert (Hashtbl.length t = 2)
 
-let () =
+let basics () =
   let t = Hashtbl.create () in
   assert (Hashtbl.length t = 0);
   Hashtbl.replace t "foo" 101;
@@ -91,4 +91,11 @@ let () =
   assert (Hashtbl.length t = 1);
   assert (Hashtbl.to_seq t |> List.of_seq |> List.sort compare = [ ("bar", 19) ])
 
-let () = Printf.printf "Test Hashtbl OK!\n%!"
+let () =
+  Alcotest.run "Stack"
+    [
+      ("replace and remove", [ Alcotest.test_case "" `Quick replace_and_remove ]);
+      ("large tx", [ Alcotest.test_case "" `Quick large_tx ]);
+      ("large ops", [ Alcotest.test_case "" `Quick large_ops ]);
+      ("basics", [ Alcotest.test_case "" `Quick basics ]);
+    ]

--- a/test/kcas_data/mvar_test.ml
+++ b/test/kcas_data/mvar_test.ml
@@ -1,7 +1,7 @@
 open Kcas
 open Kcas_data
 
-let () =
+let basics () =
   let mv = Mvar.create (Some 101) in
   assert (not (Mvar.is_empty mv));
   assert (Mvar.take mv = 101);
@@ -17,6 +17,7 @@ let () =
   assert (Mvar.take running = ());
   assert (Xt.commit { tx = Mvar.Xt.take mv } = 42);
   Domain.join d;
-  assert (Mvar.take mv = 76);
+  assert (Mvar.take mv = 76)
 
-  Printf.printf "Test Mvar OK!\n%!"
+let () =
+  Alcotest.run "Mvar" [ ("basics", [ Alcotest.test_case "" `Quick basics ]) ]

--- a/test/kcas_data/queue_test.ml
+++ b/test/kcas_data/queue_test.ml
@@ -1,7 +1,7 @@
 open Kcas
 open Kcas_data
 
-let () =
+let basics () =
   let q = Queue.create () in
   Queue.add 101 q;
   let tx ~xt =
@@ -11,9 +11,7 @@ let () =
     assert (Queue.Xt.take_opt ~xt q = Some 42);
     assert (Queue.Xt.take_opt ~xt q = None)
   in
-  Xt.commit { tx }
-
-let () =
+  Xt.commit { tx };
   let q = Queue.create () in
   assert (Queue.length q = 0);
   assert (Queue.is_empty q);
@@ -30,6 +28,7 @@ let () =
   assert (Queue.take_opt q = None);
   assert (Queue.take_opt r = Some 101);
   assert (Queue.take_opt r = Some 42);
-  assert (Queue.take_opt r = None);
+  assert (Queue.take_opt r = None)
 
-  Printf.printf "Test Queue OK!\n%!"
+let () =
+  Alcotest.run "Queue" [ ("basics", [ Alcotest.test_case "" `Quick basics ]) ]

--- a/test/kcas_data/stack_test.ml
+++ b/test/kcas_data/stack_test.ml
@@ -1,6 +1,6 @@
 open Kcas_data
 
-let () =
+let basics () =
   let s = Stack.create () in
   assert (Stack.length s = 0);
   assert (Stack.is_empty s);
@@ -18,6 +18,7 @@ let () =
   assert (Stack.length t = 2);
   assert (Stack.pop_opt t = Some 42);
   assert (Stack.pop_opt t = Some 101);
-  assert (Stack.pop_opt t = None);
+  assert (Stack.pop_opt t = None)
 
-  Printf.printf "Test Stack OK!\n%!"
+let () =
+  Alcotest.run "Stack" [ ("basics", [ Alcotest.test_case "" `Quick basics ]) ]

--- a/test/kcas_data/xt_test.ml
+++ b/test/kcas_data/xt_test.ml
@@ -3,7 +3,7 @@ module Q = Xt_linked_queue
 module P = Kcas_data.Queue
 module S = Xt_stack
 
-let () =
+let basics () =
   let p = P.create () and q = Q.create () and s = S.create () in
 
   (* Populate [p] with two items atomically  *)
@@ -33,6 +33,8 @@ let () =
   assert (Xt.commit { tx = P.Xt.is_empty p });
 
   Xt.commit { tx = Q.push_front q 101 };
-  assert (not (Xt.commit { tx = Q.is_empty q }));
+  assert (not (Xt.commit { tx = Q.is_empty q }))
 
-  Printf.printf "Test Xt OK!\n%!"
+let () =
+  Alcotest.run "Transactions"
+    [ ("basics", [ Alcotest.test_case "" `Quick basics ]) ]


### PR DESCRIPTION
This PR changes tests to use alcotest to get prettier output.  The tests don't yet use alcotest checks.  I'll leave that to future work.