### PR TITLE
Prefer `tests` stanza as it is concise and allows sharing modules

### DIFF
--- a/test/kcas/dune
+++ b/test/kcas/dune
@@ -1,58 +1,13 @@
-(library
- (name barrier)
- (modules barrier)
- (package kcas))
-
-(test
- (name test)
- (libraries kcas barrier threads alcotest)
- (modules test)
- (package kcas))
-
-(test
- (name test_overlapping_loc)
- (libraries kcas alcotest)
- (modules test_overlapping_loc)
- (package kcas))
-
-(test
- (name benchmark)
- (libraries kcas unix)
- (modules benchmark)
- (package kcas))
-
-(test
- (name xt_benchmark)
- (libraries kcas unix)
- (modules xt_benchmark)
- (package kcas))
-
-(test
- (name xt_parallel_cmp_bench)
- (libraries kcas barrier unix)
- (modules xt_parallel_cmp_bench)
- (package kcas))
-
-(test
- (name ms_queue_test)
- (libraries kcas alcotest)
- (modules ms_queue_test)
- (package kcas))
-
-(test
- (name example)
- (libraries kcas)
- (modules example)
- (package kcas))
-
-(test
- (name threads)
- (libraries kcas threads alcotest)
- (modules threads)
- (package kcas))
-
-(test
- (name loc_modes)
- (libraries kcas barrier)
- (modules loc_modes)
+(tests
+ (names
+  test
+  test_overlapping_loc
+  benchmark
+  xt_benchmark
+  xt_parallel_cmp_bench
+  ms_queue_test
+  example
+  threads
+  loc_modes)
+ (libraries alcotest kcas threads)
  (package kcas))

--- a/test/kcas_data/dune
+++ b/test/kcas_data/dune
@@ -1,41 +1,11 @@
-(test
- (name dllist_test)
- (modules dllist_test)
- (libraries kcas kcas_data alcotest)
- (package kcas_data))
-
-(test
- (name hashtbl_bench)
- (modules hashtbl_bench)
- (libraries kcas kcas_data unix multicore-magic)
- (package kcas_data))
-
-(test
- (name hashtbl_test)
- (modules hashtbl_test)
- (libraries kcas kcas_data alcotest)
- (package kcas_data))
-
-(test
- (name mvar_test)
- (modules mvar_test)
- (libraries kcas kcas_data alcotest)
- (package kcas_data))
-
-(test
- (name queue_test)
- (modules queue_test)
- (libraries kcas kcas_data alcotest)
- (package kcas_data))
-
-(test
- (name stack_test)
- (modules stack_test)
- (libraries kcas kcas_data alcotest)
- (package kcas_data))
-
-(test
- (name xt_test)
- (modules xt_test xt_linked_queue xt_stack)
- (libraries kcas kcas_data alcotest)
+(tests
+ (names
+  dllist_test
+  hashtbl_bench
+  hashtbl_test
+  mvar_test
+  queue_test
+  stack_test
+  xt_test)
+ (libraries alcotest kcas kcas_data multicore-magic)
  (package kcas_data))


### PR DESCRIPTION
This also avoids having the internal `barrier` library appear in various places.