### PR TITLE
Port to ocaml 4.13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+Next version:
+
+- Ported to OCaml 4.13 (@polytypic)
+
 ## 0.6.1
 
 - Ported to OCaml 4.14 (@polytypic)

--- a/dune-project
+++ b/dune-project
@@ -10,7 +10,7 @@
  (synopsis "Software transactional memory based on lock-free multi-word compare-and-set")
  (description "A software transactional memory (STM) implementation based on an atomic lock-free multi-word compare-and-set (MCAS) algorithm enhanced with read-only compare operations and ability to block awaiting for changes.")
  (depends 
-  (ocaml (>= 4.14.0))
+  (ocaml (>= 4.13.0))
   (domain-local-await (>= 0.2.0))
   (domain-local-timeout (>= 0.1.0))
   (alcotest (and (>= 1.7.0) :with-test))

--- a/kcas.opam
+++ b/kcas.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ocaml-multicore/kcas"
 bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
 depends: [
   "dune" {>= "3.3"}
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.13.0"}
   "domain-local-await" {>= "0.2.0"}
   "domain-local-timeout" {>= "0.1.0"}
   "alcotest" {>= "1.7.0" & with-test}

--- a/test/kcas_data/hashtbl_test.ml
+++ b/test/kcas_data/hashtbl_test.ml
@@ -8,7 +8,7 @@ let replace_and_remove () =
     Hashtbl.replace t i i
   done;
   assert (Hashtbl.length t = n);
-  assert (Seq.length (Hashtbl.to_seq t) = n);
+  assert (Seq.fold_left (fun n _ -> n + 1) 0 (Hashtbl.to_seq t) = n);
   for i = 1 to n do
     assert (Hashtbl.find t i = i)
   done;
@@ -26,7 +26,7 @@ let large_tx () =
     done
   in
   Xt.commit { tx };
-  assert (Seq.length (Hashtbl.to_seq t) = n);
+  assert (Seq.fold_left (fun n _ -> n + 1) 0 (Hashtbl.to_seq t) = n);
   let tx ~xt =
     for i = 1 to n do
       assert (Hashtbl.Xt.find_opt ~xt t i = Some i)


### PR DESCRIPTION
This PR removes two uses of `Seq.length` allowing Kcas to build on OCaml 4.13.

The next step would be to remove uses of `Int.min` and `Int.max` allowing Kcas to build on OCaml 4.12.