### PR TITLE
Pass through `?timeoutf` to blocking operations on data structures

### DIFF
--- a/src/kcas_data/dllist.ml
+++ b/src/kcas_data/dllist.ml
@@ -173,8 +173,13 @@ let move_l node list = Kcas.Xt.commit { tx = Xt.move_l node list }
 let move_r node list = Kcas.Xt.commit { tx = Xt.move_r node list }
 let take_opt_l list = Kcas.Xt.commit { tx = Xt.take_opt_l list }
 let take_opt_r list = Kcas.Xt.commit { tx = Xt.take_opt_r list }
-let take_blocking_l list = Kcas.Xt.commit { tx = Xt.take_blocking_l list }
-let take_blocking_r list = Kcas.Xt.commit { tx = Xt.take_blocking_r list }
+
+let take_blocking_l ?timeoutf list =
+  Kcas.Xt.commit ?timeoutf { tx = Xt.take_blocking_l list }
+
+let take_blocking_r ?timeoutf list =
+  Kcas.Xt.commit ?timeoutf { tx = Xt.take_blocking_r list }
+
 let swap t1 t2 = Kcas.Xt.commit { tx = Xt.swap t1 t2 }
 let transfer_l t1 t2 = Kcas.Xt.commit { tx = Xt.transfer_l t1 t2 }
 let transfer_r t1 t2 = Kcas.Xt.commit { tx = Xt.transfer_r t1 t2 }

--- a/src/kcas_data/dllist.mli
+++ b/src/kcas_data/dllist.mli
@@ -52,6 +52,7 @@ module Xt :
     with type 'a t := 'a t
     with type 'a node := 'a node
     with type ('x, 'fn) fn := xt:'x Xt.t -> 'fn
+    with type ('x, 'fn) blocking_fn := xt:'x Xt.t -> 'fn
 (** Explicit transaction log passing on doubly-linked lists. *)
 
 (** {1 Non-compositional interface} *)
@@ -61,6 +62,7 @@ include
     with type 'a t := 'a t
     with type 'a node := 'a node
     with type ('x, 'fn) fn := 'fn
+    with type ('x, 'fn) blocking_fn := ?timeoutf:float -> 'fn
 
 val take_all : 'a t -> 'a t
 (** [take_all l] removes all nodes of the doubly-linked list [l] and returns a

--- a/src/kcas_data/dllist_intf.ml
+++ b/src/kcas_data/dllist_intf.ml
@@ -2,6 +2,7 @@ module type Ops = sig
   type 'a t
   type 'a node
   type ('x, 'fn) fn
+  type ('x, 'fn) blocking_fn
 
   val remove : ('x, 'a node -> unit) fn
   (** [remove n] removes the node [n] from the doubly-linked list it is part of.
@@ -35,12 +36,12 @@ module type Ops = sig
   (** [take_opt_r l] removes and returns the value of rightmost node of the
       doubly-linked list [l], or return [None] if the list is empty. *)
 
-  val take_blocking_l : ('x, 'a t -> 'a) fn
+  val take_blocking_l : ('x, 'a t -> 'a) blocking_fn
   (** [take_blocking_l l] removes and returns the value of leftmost node of the
       doubly-linked list [l], or blocks waiting for the list to become
       non-empty. *)
 
-  val take_blocking_r : ('x, 'a t -> 'a) fn
+  val take_blocking_r : ('x, 'a t -> 'a) blocking_fn
   (** [take_blocking_r l] removes and returns the value of rightmost node of the
       doubly-linked list [l], or blocks waiting for the list to become
       non-empty. *)

--- a/src/kcas_data/mvar.ml
+++ b/src/kcas_data/mvar.ml
@@ -26,17 +26,18 @@ end
 
 let is_empty mv = Magic_option.is_none (Loc.get mv)
 
-let put mv value =
+let put ?timeoutf mv value =
   (* Fenceless is safe as we always update. *)
-  Loc.fenceless_modify mv (Magic_option.put_or_retry value)
+  Loc.fenceless_modify ?timeoutf mv (Magic_option.put_or_retry value)
 
 let try_put mv value =
   Loc.compare_and_set mv Magic_option.none (Magic_option.some value)
 
-let take mv =
+let take ?timeoutf mv =
   (* Fenceless is safe as we always update. *)
-  Magic_option.get_unsafe (Loc.fenceless_update mv Magic_option.take_or_retry)
+  Magic_option.get_unsafe
+    (Loc.fenceless_update ?timeoutf mv Magic_option.take_or_retry)
 
 let take_opt mv = Magic_option.to_option (Loc.exchange mv Magic_option.none)
-let peek mv = Loc.get_as Magic_option.get_or_retry mv
+let peek ?timeoutf mv = Loc.get_as ?timeoutf Magic_option.get_or_retry mv
 let peek_opt mv = Magic_option.to_option (Loc.get mv)

--- a/src/kcas_data/mvar.mli
+++ b/src/kcas_data/mvar.mli
@@ -26,8 +26,13 @@ module Xt :
   Mvar_intf.Ops
     with type 'a t := 'a t
     with type ('x, 'fn) fn := xt:'x Xt.t -> 'fn
+    with type ('x, 'fn) blocking_fn := xt:'x Xt.t -> 'fn
 (** Explicit transaction passing on synchronizing variables. *)
 
 (** {1 Non-compositional interface} *)
 
-include Mvar_intf.Ops with type 'a t := 'a t with type ('x, 'fn) fn := 'fn
+include
+  Mvar_intf.Ops
+    with type 'a t := 'a t
+    with type ('x, 'fn) fn := 'fn
+    with type ('x, 'fn) blocking_fn := ?timeoutf:float -> 'fn

--- a/src/kcas_data/mvar_intf.ml
+++ b/src/kcas_data/mvar_intf.ml
@@ -1,12 +1,13 @@
 module type Ops = sig
   type 'a t
   type ('x, 'fn) fn
+  type ('x, 'fn) blocking_fn
 
   val is_empty : ('x, 'a t -> bool) fn
   (** [is_empty mv] determines whether the synchronizing variable [mv] contains
       a value or not. *)
 
-  val put : ('x, 'a t -> 'a -> unit) fn
+  val put : ('x, 'a t -> 'a -> unit) blocking_fn
   (** [put mv x] fills the synchronizing variable [mv] with the value [v] or
       blocks until the variable becomes empty. *)
 
@@ -15,7 +16,7 @@ module type Ops = sig
       value [v] and returns [true] on success or [false] in case the variable is
       full. *)
 
-  val take : ('x, 'a t -> 'a) fn
+  val take : ('x, 'a t -> 'a) blocking_fn
   (** [take mv] removes and returns the current value of the synchronizing
       variable [mv] or blocks waiting until the variable is filled. *)
 
@@ -23,7 +24,7 @@ module type Ops = sig
   (** [take_opt mv] removes and returns the current value of the synchronizing
       variable [mv] or returns [None] in case the variable is empty. *)
 
-  val peek : ('x, 'a t -> 'a) fn
+  val peek : ('x, 'a t -> 'a) blocking_fn
   (** [peek mv] returns the current value of the synchronizing variable [mv] or
       blocks waiting until the variable is filled. *)
 

--- a/src/kcas_data/promise.ml
+++ b/src/kcas_data/promise.ml
@@ -38,7 +38,8 @@ module Xt = struct
   let resolve_error ~xt u e = resolve ~xt u (Error e)
 end
 
-let await t = Loc.get_as Magic_option.get_or_retry (of_promise t)
+let await ?timeoutf t =
+  Loc.get_as ?timeoutf Magic_option.get_or_retry (of_promise t)
 
 let resolve u v =
   if
@@ -50,8 +51,8 @@ let resolve u v =
 let peek t = Magic_option.to_option (Loc.get (of_promise t))
 let is_resolved t = Magic_option.is_some (Loc.get (of_promise t))
 
-let await_exn t =
-  match await t with Ok value -> value | Error exn -> raise exn
+let await_exn ?timeoutf t =
+  match await ?timeoutf t with Ok value -> value | Error exn -> raise exn
 
 let resolve_ok u v = resolve u (Ok v)
 let resolve_error u e = resolve u (Error e)

--- a/src/kcas_data/promise.mli
+++ b/src/kcas_data/promise.mli
@@ -42,6 +42,7 @@ module Xt :
     with type 'a or_exn := 'a or_exn
     with type 'a u := 'a u
     with type ('x, 'fn) fn := xt:'x Xt.t -> 'fn
+    with type ('x, 'fn) blocking_fn := xt:'x Xt.t -> 'fn
 (** Explicit transaction log passing on promises. *)
 
 (** {1 Non-compositional interface} *)
@@ -52,3 +53,4 @@ include
     with type 'a or_exn := 'a or_exn
     with type 'a u := 'a u
     with type ('x, 'fn) fn := 'fn
+    with type ('x, 'fn) blocking_fn := ?timeoutf:float -> 'fn

--- a/src/kcas_data/promise_intf.ml
+++ b/src/kcas_data/promise_intf.ml
@@ -3,13 +3,14 @@ module type Ops = sig
   type !-'a u
   type 'a or_exn
   type ('x, 'fn) fn
+  type ('x, 'fn) blocking_fn
 
   val resolve : ('x, 'a u -> 'a -> unit) fn
   (** [resolve u v] resolves the promise corresponding to the resolver [u] to
       the value [v].  Any awaiters of the corresponding promise are then
       unblocked. *)
 
-  val await : ('x, 'a t -> 'a) fn
+  val await : ('x, 'a t -> 'a) blocking_fn
   (** [await t] either immediately returns the resolved value of the promise [t]
       or blocks until the promise [t] is resolved. *)
 
@@ -23,7 +24,7 @@ module type Ops = sig
 
   (** {2 Result promises} *)
 
-  val await_exn : ('x, 'a or_exn -> 'a) fn
+  val await_exn : ('x, 'a or_exn -> 'a) blocking_fn
   (** [await_exn t] is equivalent to [match await t with v -> v | exception e -> raise e]. *)
 
   val resolve_ok : ('x, ('a, 'b) result u -> 'a -> unit) fn

--- a/src/kcas_data/queue.ml
+++ b/src/kcas_data/queue.ml
@@ -139,10 +139,10 @@ let take_opt q =
   | None -> Kcas.Xt.commit { tx = Xt.take_opt q }
   | some -> some
 
-let take_blocking q =
+let take_blocking ?timeoutf q =
   (* Fenceless is safe as we revert to a transaction in case we didn't update. *)
   match Loc.fenceless_update q.front Elems.tl_safe |> Elems.hd_opt with
-  | None -> Kcas.Xt.commit { tx = Xt.take_blocking q }
+  | None -> Kcas.Xt.commit ?timeoutf { tx = Xt.take_blocking q }
   | Some elem -> elem
 
 let take_all q = Kcas.Xt.commit { tx = Xt.take_all q }
@@ -152,7 +152,9 @@ let peek_opt q =
   | None -> Kcas.Xt.commit { tx = Xt.peek_opt q }
   | some -> some
 
-let peek_blocking q = Kcas.Xt.commit { tx = Xt.peek_blocking q }
+let peek_blocking ?timeoutf q =
+  Kcas.Xt.commit ?timeoutf { tx = Xt.peek_blocking q }
+
 let clear q = Kcas.Xt.commit { tx = Xt.clear q }
 let swap q1 q2 = Kcas.Xt.commit { tx = Xt.swap q1 q2 }
 let to_seq q = Kcas.Xt.commit { tx = Xt.to_seq q }

--- a/src/kcas_data/queue.mli
+++ b/src/kcas_data/queue.mli
@@ -31,11 +31,16 @@ module Xt :
   Queue_intf.Ops
     with type 'a t := 'a t
     with type ('x, 'fn) fn := xt:'x Xt.t -> 'fn
+    with type ('x, 'fn) blocking_fn := xt:'x Xt.t -> 'fn
 (** Explicit transaction log passing on queues. *)
 
 (** {1 Non-compositional interface} *)
 
-include Queue_intf.Ops with type 'a t := 'a t with type ('x, 'fn) fn := 'fn
+include
+  Queue_intf.Ops
+    with type 'a t := 'a t
+    with type ('x, 'fn) fn := 'fn
+    with type ('x, 'fn) blocking_fn := ?timeoutf:float -> 'fn
 
 val peek : 'a t -> 'a
 (** [peek q] returns the first element in queue [s], or raises {!Empty} if the

--- a/src/kcas_data/queue_intf.ml
+++ b/src/kcas_data/queue_intf.ml
@@ -1,6 +1,7 @@
 module type Ops = sig
   type 'a t
   type ('x, 'fn) fn
+  type ('x, 'fn) blocking_fn
 
   val is_empty : ('x, 'a t -> bool) fn
   (** [is_empty s] determines whether the queue [q] is empty. *)
@@ -31,11 +32,11 @@ module type Ops = sig
   (** [peek_opt q] returns the first element in queue [q], without removing it
       from the queue, or returns [None] if the queue is empty. *)
 
-  val peek_blocking : ('x, 'a t -> 'a) fn
+  val peek_blocking : ('x, 'a t -> 'a) blocking_fn
   (** [peek_blocking q] returns the first element in queue [q], without removing
       it from the queue, or blocks waiting for the queue to become non-empty. *)
 
-  val take_blocking : ('x, 'a t -> 'a) fn
+  val take_blocking : ('x, 'a t -> 'a) blocking_fn
   (** [take_blocking q] removes and returns the first element in queue [q], or
       blocks waiting for the queue to become non-empty. *)
 

--- a/src/kcas_data/stack.ml
+++ b/src/kcas_data/stack.ml
@@ -33,12 +33,12 @@ let push x s =
 let pop_opt s = Loc.update s Elems.tl_safe |> Elems.hd_opt
 let pop_all s = Loc.exchange s Elems.empty |> Elems.to_seq
 
-let pop_blocking s =
+let pop_blocking ?timeoutf s =
   (* Fenceless is safe as we always update. *)
-  Loc.fenceless_update s Elems.tl_or_retry |> Elems.hd_unsafe
+  Loc.fenceless_update ?timeoutf s Elems.tl_or_retry |> Elems.hd_unsafe
 
 let top_opt s = Loc.get s |> Elems.hd_opt
-let top_blocking s = Loc.get_as Elems.hd_or_retry s
+let top_blocking ?timeoutf s = Loc.get_as ?timeoutf Elems.hd_or_retry s
 let clear s = Loc.set s Elems.empty
 let swap s1 s2 = Kcas.Xt.commit { tx = Kcas.Xt.swap s1 s2 }
 let to_seq s = Elems.to_seq @@ Loc.get s

--- a/src/kcas_data/stack.mli
+++ b/src/kcas_data/stack.mli
@@ -33,11 +33,16 @@ module Xt :
   Stack_intf.Ops
     with type 'a t := 'a t
     with type ('x, 'fn) fn := xt:'x Xt.t -> 'fn
+    with type ('x, 'fn) blocking_fn := xt:'x Xt.t -> 'fn
 (** Explicit transaction log passing on stacks. *)
 
 (** {1 Non-compositional interface} *)
 
-include Stack_intf.Ops with type 'a t := 'a t with type ('x, 'fn) fn := 'fn
+include
+  Stack_intf.Ops
+    with type 'a t := 'a t
+    with type ('x, 'fn) fn := 'fn
+    with type ('x, 'fn) blocking_fn := ?timeoutf:float -> 'fn
 
 val pop : 'a t -> 'a
 (** [pop s] removes and returns the topmost element in stack [s], or raises

--- a/src/kcas_data/stack_intf.ml
+++ b/src/kcas_data/stack_intf.ml
@@ -1,6 +1,7 @@
 module type Ops = sig
   type 'a t
   type ('x, 'fn) fn
+  type ('x, 'fn) blocking_fn
 
   val is_empty : ('x, 'a t -> bool) fn
   (** [is_empty s] determines whether the stack [s] is empty. *)
@@ -32,7 +33,7 @@ module type Ops = sig
   (** [pop_all s] removes and returns a domain safe sequence for iterating
       through all the elements that were in the stack top to bottom. *)
 
-  val pop_blocking : ('x, 'a t -> 'a) fn
+  val pop_blocking : ('x, 'a t -> 'a) blocking_fn
   (** [pop_blocking s] removes and returns the topmost element of the stack [s],
       or blocks waiting for the queue to become non-empty. *)
 
@@ -40,7 +41,7 @@ module type Ops = sig
   (** [top_opt s] returns the topmost element in stack [s], or [None] if the
       stack is empty. *)
 
-  val top_blocking : ('x, 'a t -> 'a) fn
+  val top_blocking : ('x, 'a t -> 'a) blocking_fn
   (** [top_blocking s] returns the topmost element in stack [s], or blocks
       waiting for the queue to become non-empty. *)
 end


### PR DESCRIPTION
This PR adds `?timeoutf` argument pass-through to blocking non-compositional operations on data structures, which allows convenient use of such operations with timeouts.
