### PR TITLE
Adopt OCaml Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Code of Conduct
+
+This project has adopted the
+[OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct
+[enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+
+To report any violations, please contact:
+
+- Vesa Karvonen <vesa [at] tarides [dot] com>
+- Carine Morel <carine [at] tarides [dot] com>
+- Sudha Parimala <sudha [at] tarides [dot] com>


### PR DESCRIPTION
This code of conduct lives in [ocaml/code-of-conduct](https://github.com/ocaml/code-of-conduct) and has been discussed in [this thread](https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494).

It has been adopted by the OCaml compiler and many platform tools. We propose adopting it for Kcas.

cc @lyrm @Sudha247 