### PR TITLE
Support padding to avoid false sharing

### DIFF
--- a/bench/bench_hashtbl.ml
+++ b/bench/bench_hashtbl.ml
@@ -9,10 +9,7 @@ end
 
 let run_one ~n_domains ?(factor = 1) ?(n_ops = 50 * factor * Util.iter_factor)
     ?(n_keys = 1000) ~percent_read () =
-  let t =
-    Hashtbl.create ~hashed_type:(module Int) ()
-    |> Multicore_magic.copy_as_padded
-  in
+  let t = Hashtbl.create ~hashed_type:(module Int) () in
 
   for i = 0 to n_keys - 1 do
     Hashtbl.replace t i i

--- a/bench/bench_parallel_cmp.ml
+++ b/bench/bench_parallel_cmp.ml
@@ -2,10 +2,9 @@ open Kcas
 open Bench
 
 let run_one ?(factor = 1) ?(n_iter = 10 * factor * Util.iter_factor) () =
-  let a = Loc.make 10 |> Multicore_magic.copy_as_padded
-  and b = Loc.make 52 |> Multicore_magic.copy_as_padded in
+  let a = Loc.make ~padded:true 10 and b = Loc.make ~padded:true 52 in
 
-  let init _ = Loc.make 0 |> Multicore_magic.copy_as_padded in
+  let init _ = Loc.make ~padded:true 0 in
   let work i x =
     if i land 1 = 0 then begin
       let tx1 ~xt =

--- a/src/kcas/dune
+++ b/src/kcas/dune
@@ -1,7 +1,7 @@
 (library
  (name kcas)
  (public_name kcas)
- (libraries domain-local-await domain-local-timeout))
+ (libraries domain-local-await domain-local-timeout multicore-magic))
 
 (rule
  (targets domain.ml)

--- a/src/kcas/kcas.mli
+++ b/src/kcas/kcas.mli
@@ -79,9 +79,16 @@ module Loc : sig
   type !'a t
   (** Type of shared memory locations. *)
 
-  val make : ?mode:Mode.t -> 'a -> 'a t
+  val make : ?padded:bool -> ?mode:Mode.t -> 'a -> 'a t
   (** [make initial] creates a new shared memory location with the [initial]
       value.
+
+      The optional [padded] argument defaults to [false].  If explicitly
+      specified as [~padded:true] the location will be allocated in a way to
+      avoid false sharing.  For relatively long lived shared memory locations
+      this can improve performance and make performance more stable at the cost
+      of using more memory.  It is not recommended to use [~padded:true] for
+      short lived shared memory locations.
 
       The optional [mode] argument defaults to {!Mode.obstruction_free}.  If
       explicitly specified as {!Mode.lock_free}, the location will always be
@@ -89,7 +96,10 @@ module Loc : sig
       in rare cases where a location is updated frequently and obstruction-free
       read-only accesses would almost certainly suffer from interference. *)
 
-  val make_array : ?mode:Mode.t -> int -> 'a -> 'a t array
+  val make_contended : ?mode:Mode.t -> 'a -> 'a t
+  (** [make_contended initial] is equivalent to [make ~padded:true initial]. *)
+
+  val make_array : ?padded:bool -> ?mode:Mode.t -> int -> 'a -> 'a t array
   (** [make_array n initial] creates an array of [n] new shared memory locations
       with the [initial] value. *)
 

--- a/src/kcas_data/accumulator.ml
+++ b/src/kcas_data/accumulator.ml
@@ -11,7 +11,7 @@ let make ?n_way n =
     | None -> n_way_default
     | Some n_way -> n_way |> Int.min n_way_max |> Bits.ceil_pow_2
   in
-  let a = Loc.make_array ~mode:Mode.lock_free n_way 0 in
+  let a = Loc.make_array ~padded:true ~mode:Mode.lock_free n_way 0 in
   Loc.set (Array.unsafe_get a 0) n;
   a
 

--- a/src/kcas_data/dune
+++ b/src/kcas_data/dune
@@ -1,7 +1,7 @@
 (library
  (name kcas_data)
  (public_name kcas_data)
- (libraries kcas))
+ (libraries kcas multicore-magic))
 
 (rule
  (targets domain.ml)

--- a/src/kcas_data/mvar.ml
+++ b/src/kcas_data/mvar.ml
@@ -2,7 +2,7 @@ open Kcas
 
 type 'a t = 'a Magic_option.t Loc.t
 
-let create x_opt = Loc.make (Magic_option.of_option x_opt)
+let create x_opt = Loc.make ~padded:true (Magic_option.of_option x_opt)
 
 module Xt = struct
   let is_empty ~xt mv = Magic_option.is_none (Xt.get ~xt mv)

--- a/src/kcas_data/queue.ml
+++ b/src/kcas_data/queue.ml
@@ -9,10 +9,10 @@ type 'a t = {
 let alloc ~front ~middle ~back =
   (* We allocate locations in specific order to make most efficient use of the
      splay-tree based transaction log. *)
-  let front = Loc.make front
-  and middle = Loc.make middle
-  and back = Loc.make back in
-  { back; middle; front }
+  let front = Loc.make ~padded:true front
+  and middle = Loc.make ~padded:true middle
+  and back = Loc.make ~padded:true back in
+  Multicore_magic.copy_as_padded { back; middle; front }
 
 let create () = alloc ~front:Elems.empty ~middle:Elems.empty ~back:Elems.empty
 

--- a/src/kcas_data/stack.ml
+++ b/src/kcas_data/stack.ml
@@ -2,9 +2,9 @@ open Kcas
 
 type 'a t = 'a Elems.t Loc.t
 
-let create () = Loc.make Elems.empty
-let copy s = Loc.make @@ Loc.get s
-let of_seq xs = Loc.make (Elems.of_seq_rev xs)
+let create () = Loc.make ~padded:true Elems.empty
+let copy s = Loc.make ~padded:true @@ Loc.get s
+let of_seq xs = Loc.make ~padded:true (Elems.of_seq_rev xs)
 
 module Xt = struct
   let length ~xt s = Xt.get ~xt s |> Elems.length


### PR DESCRIPTION
This PR adds support for padding to avoid false sharing.

OCaml Stdlib recently got added a way allocate [cache-aligned atomics](https://github.com/ocaml/ocaml/pull/12212).  To mirror the development, the `Loc` module is extended with a `make_contended` function.  However, the approach in this PR is to add an optional boolean argument `padded` to relevant constructor functions, i.e. `Loc.make ~padded:true`.

Why not name the argument `contended`?  False sharing is a specific kind of contention.  However, you can have contention even when you don't have false sharing simply because the same location is being accessed by multiple domains / cores.  Using `make_contended` doesn't help with that at all and the term `contended` is potentially misleading.

This PR also makes data structures use padded locations and also pad other parts where it should be advantageous using [multicore-magic](https://github.com/ocaml-multicore/multicore-magic).

For background, **_false sharing has absolutely nothing to do with atomics_** per se.  False sharing happens whenever there is at least one core writing and other cores accessing (reading or writing) something that happens to map to the same cache line (aligned region of memory).  It doesn't have to involve atomics at all.  The word being written to could just be a regular mutable record field (to which no other core has access to) and the other cores might just be reading fields of immutable records that happen to be in the same cache line.  This is something that happens very easily and even commonly.  I've had to work around these issues regularly while trying to optimize and benchmark multicore OCaml code.

False sharing can signficantly degrade performance unless carefully avoided.   While developing this PR, I saw a major performance improvement with the `Hashtbl` after adding padding:

```
Benchmark 1: kcas-main/_build/default/test/kcas_data/hashtbl_bench.exe 2 1_000_000 1000 10
  Time (mean ± σ):     123.3 ms ±   2.8 ms    [User: 240.5 ms, System: 1.9 ms]
  Range (min … max):   122.4 ms … 136.3 ms    24 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: kcas-this/_build/default/test/kcas_data/hashtbl_bench.exe 2 1_000_000 1000 10
  Time (mean ± σ):      94.1 ms ±   0.2 ms    [User: 183.0 ms, System: 1.6 ms]
  Range (min … max):    93.9 ms …  94.6 ms    31 runs
 
Summary
  kcas-this/_build/default/test/kcas_data/hashtbl_bench.exe 2 1_000_000 1000 10 ran
    1.31 ± 0.03 times faster than kcas-main/_build/default/test/kcas_data/hashtbl_bench.exe 2 1_000_000 1000 10


Benchmark 1: kcas-main/_build/default/test/kcas_data/hashtbl_bench.exe 4 1_000_000 1000 10
  Time (mean ± σ):      68.7 ms ±   0.3 ms    [User: 260.3 ms, System: 2.6 ms]
  Range (min … max):    67.9 ms …  69.6 ms    43 runs
 
Benchmark 2: kcas-this/_build/default/test/kcas_data/hashtbl_bench.exe 4 1_000_000 1000 10
  Time (mean ± σ):      53.3 ms ±   0.4 ms    [User: 198.6 ms, System: 2.6 ms]
  Range (min … max):    52.8 ms …  55.2 ms    55 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  kcas-this/_build/default/test/kcas_data/hashtbl_bench.exe 4 1_000_000 1000 10 ran
    1.29 ± 0.01 times faster than kcas-main/_build/default/test/kcas_data/hashtbl_bench.exe 4 1_000_000 1000 10
```
