### PR TITLE
Remove links to old API references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-[API reference](https://ocaml-multicore.github.io/kcas/doc/) &middot;
-<sub><sup>(The `Tx` API was removed in version 0.3.0 &mdash; see
-[API reference for version 0.2.4](https://ocaml-multicore.github.io/kcas/0.2.4/index.html).
-The API was redesigned in version 0.2.0 &mdash; see
-[API reference for version 0.1.8](https://ocaml-multicore.github.io/kcas/0.1.8/kcas/Kcas/index.html).)</sup></sub>
+[API reference](https://ocaml-multicore.github.io/kcas/doc/)
 
 <div align="center">
 


### PR DESCRIPTION
This PR removes links to the old API references, because they clutter the README.  I strongly doubt anybody is interested in the old API references.  My plan is to create a simple root page in gh-pages that will also contain links to the old API references.