### PR TITLE
Avoid allocation in no-op update

### DIFF
--- a/src/kcas/kcas.ml
+++ b/src/kcas/kcas.ml
@@ -715,7 +715,8 @@ module Xt = struct
     end
     else
       let current = state.after in
-      let state = { state with after = f current } in
+      let after = f current in
+      let state = if current == after then state else { state with after } in
       tree_as_ref xt := T (Node { loc; state; lt; gt; awaiters = [] });
       current
 


### PR DESCRIPTION
This PR makes a minor tweak to avoid an allocation in a no-op update.