### PR TITLE
Use `Multicore_magic.domain_hash` in `Kcas_data.Accumulator`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,7 @@
   (backoff (>= 0.1.0))
   (domain-local-await (>= 1.0.0))
   (domain-local-timeout (>= 1.0.0))
-  (multicore-magic (>= 2.0.0))
+  (multicore-magic (>= 2.1.0))
   (domain_shims (and (>= 0.1.0) :with-test))
   (alcotest (and (>= 1.7.0) :with-test))
   (mdx (and (>= 2.3.0) :with-test))
@@ -25,7 +25,7 @@
  (description "A library of compositional lock-free data structures and primitives for communication and synchronization implemented using kcas.")
  (depends
   (kcas (= :version))
-  (multicore-magic (>= 2.0.0))
+  (multicore-magic (>= 2.1.0))
   (domain-local-await (and (>= 1.0.0) :with-test))
   (domain_shims (and (>= 0.1.0) :with-test))
   (mtime (and (>= 2.0.0) :with-test))

--- a/kcas.opam
+++ b/kcas.opam
@@ -18,7 +18,7 @@ depends: [
   "backoff" {>= "0.1.0"}
   "domain-local-await" {>= "1.0.0"}
   "domain-local-timeout" {>= "1.0.0"}
-  "multicore-magic" {>= "2.0.0"}
+  "multicore-magic" {>= "2.1.0"}
   "domain_shims" {>= "0.1.0" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
   "mdx" {>= "2.3.0" & with-test}
@@ -40,3 +40,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
 doc: "https://ocaml-multicore.github.io/kcas/doc/kcas/Kcas/"
+pin-depends: [
+  [ "multicore-magic.dev" "git+https://github.com/ocaml-multicore/multicore-magic#e7abfa84e0657d7d56f977a5695f5c20b1f465a1" ]
+]

--- a/kcas.opam.template
+++ b/kcas.opam.template
@@ -1,1 +1,4 @@
 doc: "https://ocaml-multicore.github.io/kcas/doc/kcas/Kcas/"
+pin-depends: [
+  [ "multicore-magic.dev" "git+https://github.com/ocaml-multicore/multicore-magic#e7abfa84e0657d7d56f977a5695f5c20b1f465a1" ]
+]

--- a/kcas_data.opam
+++ b/kcas_data.opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
 depends: [
   "dune" {>= "3.8"}
   "kcas" {= version}
-  "multicore-magic" {>= "2.0.0"}
+  "multicore-magic" {>= "2.1.0"}
   "domain-local-await" {>= "1.0.0" & with-test}
   "domain_shims" {>= "0.1.0" & with-test}
   "mtime" {>= "2.0.0" & with-test}

--- a/src/kcas_data/accumulator.ml
+++ b/src/kcas_data/accumulator.ml
@@ -18,8 +18,7 @@ let make ?n_way n =
 let n_way_of = Array.length
 
 let get_self a =
-  let h = (Domain.self () :> int) in
-  (* TODO: Consider mixing the bits of [h] to get better distribution *)
+  let h = Multicore_magic.domain_hash () in
   Array.unsafe_get a (h land (Array.length a - 1))
 
 module Xt = struct


### PR DESCRIPTION
This depends on [Add `domain_hash`](https://github.com/ocaml-multicore/multicore-magic/pull/9) and should not be merged before a new version of `multicore-magic` has been published.
