### PR TITLE
Use `instantaneous_domain_index` in `Accumulator`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (domain-local-timeout
    (>= 1.0.0))
   (multicore-magic
-   (>= 2.0.0))
+   (>= 2.1.0))
   (domain_shims
    (and
     (>= 0.1.0)
@@ -65,7 +65,7 @@
   (kcas
    (= :version))
   (multicore-magic
-   (>= 2.0.0))
+   (>= 2.1.0))
   (domain-local-await
    (and
     (>= 1.0.0)

--- a/kcas.opam
+++ b/kcas.opam
@@ -18,7 +18,7 @@ depends: [
   "backoff" {>= "0.1.0"}
   "domain-local-await" {>= "1.0.0"}
   "domain-local-timeout" {>= "1.0.0"}
-  "multicore-magic" {>= "2.0.0"}
+  "multicore-magic" {>= "2.1.0"}
   "domain_shims" {>= "0.1.0" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
   "mdx" {>= "2.3.0" & with-test}

--- a/kcas_data.opam
+++ b/kcas_data.opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
 depends: [
   "dune" {>= "3.8"}
   "kcas" {= version}
-  "multicore-magic" {>= "2.0.0"}
+  "multicore-magic" {>= "2.1.0"}
   "domain-local-await" {>= "1.0.0" & with-test}
   "domain_shims" {>= "0.1.0" & with-test}
   "mtime" {>= "2.0.0" & with-test}

--- a/src/kcas_data/accumulator.mli
+++ b/src/kcas_data/accumulator.mli
@@ -10,19 +10,8 @@ open Kcas
 type t
 (** The type of a scalable accumulator. *)
 
-val make : ?n_way:int -> int -> t
-(** [make n] returns a new accumulator whose initial value is [n].
-
-    The optional [n_way] argument can be used to specify a desired level of
-    parallelism, i.e. maximum number of non-interfering parallel updates.  The
-    default value is chosen to strike a balance between scalability and memory
-    use and a given value may be adjusted by the implementation. *)
-
-val n_way_of : t -> int
-(** [n_way_of a] returns the maximum number of non-interfering parallel updates
-    supported by the accumulator [a].
-
-    {b NOTE}: The returned value may not be the same as given to {!make}. *)
+val make : int -> t
+(** [make n] returns a new accumulator whose initial value is [n]. *)
 
 (** {1 Compositional interface} *)
 

--- a/src/kcas_data/hashtbl.mli
+++ b/src/kcas_data/hashtbl.mli
@@ -43,7 +43,6 @@ val create :
   ?hashed_type:'k hashed_type ->
   ?min_buckets:int ->
   ?max_buckets:int ->
-  ?n_way:int ->
   unit ->
   ('k, 'v) t
 (** [create ()] returns a new empty hash table.
@@ -55,8 +54,6 @@ val create :
     - The default [max_buckets] is the minimum of [1 lsl 30] and suitably
       adjusted [Sys.max_array_length] and a given [max_buckets] may be adjusted
       by the implementation.
-    - The [n_way] argument is passed to the internal {!Accumulator} used to keep
-      track of the number of bindings.
 
     Hash tables are automatically internally resized. *)
 
@@ -76,16 +73,10 @@ val max_buckets_of : ('k, 'v) t -> int
 
     {b NOTE}: The returned value may not be the same as given to {!create}. *)
 
-val n_way_of : ('k, 'v) t -> int
-(** [n_way_of t] returns the maximum number of non-interfering parallel updates
-    allowed by the internal {!Accumulator} used to keep track of the number of
-    bindings in the hash table [t]. *)
-
 val of_seq :
   ?hashed_type:'k hashed_type ->
   ?min_buckets:int ->
   ?max_buckets:int ->
-  ?n_way:int ->
   ('k * 'v) Seq.t ->
   ('k, 'v) t
 (** [of_seq assoc] creates a new hash table from the given association sequence
@@ -138,7 +129,6 @@ val rebuild :
   ?hashed_type:'k hashed_type ->
   ?min_buckets:int ->
   ?max_buckets:int ->
-  ?n_way:int ->
   ('k, 'v) t ->
   ('k, 'v) t
 (** [rebuild t] returns a copy of the given hash table [t] optionally rehashing


### PR DESCRIPTION
This PR changes `Accumulator` to use `instantaneous_domain_index` and make the accumulator grow automatically, which eliminates the need to have the optional `n_way` argument.

This depends on [Add `instantaneous_domain_index`](https://github.com/ocaml-multicore/multicore-magic/pull/10) and should not be merged before a new version of `multicore-magic` has been published.
