### PR TITLE
Change the `Op` bench to more closely match the `Xt` bench and add `Loc` benchmark

### DIFF
--- a/bench/bench_loc.ml
+++ b/bench/bench_loc.ml
@@ -1,0 +1,32 @@
+open Kcas
+open Bench
+
+let run_one ?(factor = 1) ?(n_iter = 25 * factor * Util.iter_factor) () =
+  let loc = Loc.make 0 in
+
+  let init _ = () in
+  let work _ () =
+    let rec loop i =
+      if i > 0 then begin
+        Loc.incr loc;
+        loop (i - 1)
+      end
+    in
+    loop n_iter
+  in
+
+  let times = Times.record ~n_domains:1 ~init ~work () in
+
+  List.concat
+    [
+      Stats.of_times times
+      |> Stats.scale (1_000_000_000.0 /. Float.of_int n_iter)
+      |> Stats.to_json ~name:"time per op/incr"
+           ~description:"Time to perform a single op" ~units:"ns";
+      Times.invert times |> Stats.of_times
+      |> Stats.scale (Float.of_int n_iter /. 1_000_000.0)
+      |> Stats.to_json ~name:"ops over time/incr"
+           ~description:"Number of operations performed over time" ~units:"M/s";
+    ]
+
+let run_suite ~factor = run_one ~factor ()

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -1,5 +1,6 @@
 let benchmarks =
   [
+    ("Kcas Loc", Bench_loc.run_suite);
     ("Kcas Op", Bench_op.run_suite);
     ("Kcas Xt", Bench_xt.run_suite);
     ("Kcas parallel CMP", Bench_parallel_cmp.run_suite);


### PR DESCRIPTION
This PR changes the `Op` benchmark to more closely match the `Xt` benchmark.  The `Op` benchmark has been quite useful as it mostly measures the cost of the internal k-CAS algorithm.  However, the way the benchmark prebuilds the CAS list makes it unrealistically fast when compared to the `Xt` benchmark.

This PR also adds a `Loc` benchmark that currently tests the performance of `Loc.incr` on a single domain.