### PR TITLE
Fix `Hashtbl.clear`

### DIFF
--- a/src/kcas_data/hashtbl.ml
+++ b/src/kcas_data/hashtbl.ml
@@ -328,8 +328,8 @@ module Xt = struct
   let reset ~xt t =
     let r = perform_pending ~xt t in
     Accumulator.Xt.set ~xt r.length 0;
-    Xt.set ~xt t
-      { r with pending = make_rehash 0 r.min_buckets; buckets = [||] }
+    let buckets = Loc.make_array r.min_buckets Assoc.Nil in
+    Xt.set ~xt t { r with buckets }
 
   let clear ~xt t = reset ~xt t
 

--- a/test/kcas_data/hashtbl_test.ml
+++ b/test/kcas_data/hashtbl_test.ml
@@ -89,7 +89,9 @@ let basics () =
     = [ ("bar", 19); ("foo", 76) ]);
   Hashtbl.remove t "foo";
   assert (Hashtbl.length t = 1);
-  assert (Hashtbl.to_seq t |> List.of_seq |> List.sort compare = [ ("bar", 19) ])
+  assert (Hashtbl.to_seq t |> List.of_seq |> List.sort compare = [ ("bar", 19) ]);
+  Hashtbl.reset t;
+  assert (not (Hashtbl.mem t "nope"))
 
 let () =
   Alcotest.run "Hashtbl"

--- a/test/kcas_data/hashtbl_test_stm.ml
+++ b/test/kcas_data/hashtbl_test_stm.ml
@@ -3,12 +3,13 @@ open STM
 open Kcas_data
 
 module Spec = struct
-  type cmd = Add of int | Mem of int | Remove of int | Length
+  type cmd = Add of int | Mem of int | Remove of int | Clear | Length
 
   let show_cmd = function
     | Add x -> "Add " ^ string_of_int x
     | Mem x -> "Mem " ^ string_of_int x
     | Remove x -> "Remove " ^ string_of_int x
+    | Clear -> "Clear"
     | Length -> "Length"
 
   type state = int list
@@ -19,6 +20,7 @@ module Spec = struct
       Gen.int_bound 10 |> Gen.map (fun x -> Add x);
       Gen.int_bound 10 |> Gen.map (fun x -> Mem x);
       Gen.int_bound 10 |> Gen.map (fun x -> Remove x);
+      Gen.return Clear;
       Gen.return Length;
     ]
     |> Gen.oneof |> make ~print:show_cmd
@@ -37,6 +39,7 @@ module Spec = struct
           | x' :: xs -> if x = x' then xs else x' :: drop_first xs
         in
         drop_first s
+    | Clear -> []
     | Length -> s
 
   let precond _ _ = true
@@ -46,6 +49,7 @@ module Spec = struct
     | Add x -> Res (unit, Hashtbl.add d x ())
     | Mem x -> Res (bool, Hashtbl.mem d x)
     | Remove x -> Res (unit, Hashtbl.remove d x)
+    | Clear -> Res (unit, Hashtbl.clear d)
     | Length -> Res (int, Hashtbl.length d)
 
   let postcond c (s : state) res =
@@ -53,6 +57,7 @@ module Spec = struct
     | Add _x, Res ((Unit, _), ()) -> true
     | Mem x, Res ((Bool, _), res) -> res = List.exists (( = ) x) s
     | Remove _x, Res ((Unit, _), ()) -> true
+    | Clear, Res ((Unit, _), ()) -> true
     | Length, Res ((Int, _), res) -> res = List.length s
     | _, _ -> false
 end


### PR DESCRIPTION
This PR adds a test for and fixes a logic bug in the `Hashtbl`.  The `clear` operation replaced the internal `buckets` array with an empty array `[||]` and requested rehash of the table on the next mutation operation.  Unfortunately there is of course no guarantee that the next operation is a mutation.  This PR fixes that by simply creating the new buckets array directly in `clear`.

Thanks to @Lucccyo for reporting the issue!