### PR TITLE
Inline transaction log record and use polymorphic variant for mode

### DIFF
--- a/src/kcas/kcas.mli
+++ b/src/kcas/kcas.mli
@@ -140,18 +140,17 @@ end
 
 (** Operating modes of the [k-CAS-n-CMP] algorithm. *)
 module Mode : sig
-  type t
-  (** Type of an operating mode of the [k-CAS-n-CMP] algorithm. *)
-
-  val lock_free : t
-  (** In [lock_free] mode the algorithm makes sure that at least one domain will
+  type t =
+    [ `Lock_free
+      (** In [`Lock_free] mode the algorithm makes sure that at least one domain will
       be able to make progress at the cost of performing read-only operations as
       read-write operations. *)
-
-  val obstruction_free : t
-  (** In [obstruction_free] mode the algorithm proceeds optimistically and
+    | `Obstruction_free
+      (** In [`Obstruction_free] mode the algorithm proceeds optimistically and
       allows read-only operations to fail due to interference from other domains
-      that might have been prevented in the {!lock_free} mode. *)
+      that might have been prevented in the [`Lock_free] mode. *)
+    ]
+  (** Type of an operating mode of the [k-CAS-n-CMP] algorithm. *)
 end
 
 (** {1 Individual locations}
@@ -185,8 +184,8 @@ module Loc : sig
       of using more memory.  It is not recommended to use [~padded:true] for
       short lived shared memory locations.
 
-      The optional [mode] argument defaults to {!Mode.obstruction_free}.  If
-      explicitly specified as {!Mode.lock_free}, the location will always be
+      The optional {{!Mode.t} [mode]} argument defaults to [`Obstruction_free].
+      If explicitly specified as [`Lock_free], the location will always be
       accessed using the lock-free operating mode.  This may improve performance
       in rare cases where a location is updated frequently and obstruction-free
       read-only accesses would almost certainly suffer from interference. *)
@@ -288,8 +287,9 @@ end
     done internally by the library implementation.  Only logically invisible
     writes to shared memory locations are performed during this phase.
 
-    3. In {!Mode.obstruction_free} a third phase verifies all read-only
-    operations.  This is also done internally by the library implementation.
+    3. In [`Obstruction_free] {{!Mode.t} mode} a third phase verifies all
+    read-only operations.  This is also done internally by the library
+    implementation.
 
     Each phase may fail.  In particular, in the first phase, as no changes to
     shared memory have yet been attempted, it is safe, for example, to raise
@@ -537,9 +537,9 @@ module Xt : sig
       {!Retry.Invalid} to explicitly request a retry or any other exception to
       abort the transaction.
 
-      The default for [commit] is {!Mode.obstruction_free}.  However, after
-      enough attempts have failed during the verification step, [commit]
-      switches to {!Mode.lock_free}. *)
+      The default {{!Mode.t} [mode]} for [commit] is [`Obstruction_free].
+      However, after enough attempts have failed during the verification step,
+      [commit] switches to [`Lock_free]. *)
 
   (**/**)
 

--- a/src/kcas_data/accumulator.ml
+++ b/src/kcas_data/accumulator.ml
@@ -11,7 +11,7 @@ let make ?n_way n =
     | None -> n_way_default
     | Some n_way -> n_way |> Int.min n_way_max |> Bits.ceil_pow_2
   in
-  let a = Loc.make_array ~padded:true ~mode:Mode.lock_free n_way 0 in
+  let a = Loc.make_array ~padded:true ~mode:`Lock_free n_way 0 in
   Loc.set (Array.unsafe_get a 0) n;
   a
 

--- a/test/kcas/loc_modes.ml
+++ b/test/kcas/loc_modes.ml
@@ -5,9 +5,9 @@ let loop_count = try int_of_string Sys.argv.(1) with _ -> Util.iter_factor
 let mode =
   Some
     (try
-       if Sys.argv.(2) = "obstruction-free" then Mode.obstruction_free
-       else Mode.lock_free
-     with _ -> Mode.lock_free)
+       if Sys.argv.(2) = "obstruction-free" then `Obstruction_free
+       else `Lock_free
+     with _ -> `Lock_free)
 
 (* Number of shared counters being used to try to cause interference *)
 

--- a/test/kcas/test.ml
+++ b/test/kcas/test.ml
@@ -44,7 +44,7 @@ let run_domains = function
 (* *)
 
 let test_non_linearizable_xt () =
-  [ Mode.obstruction_free; Mode.lock_free ]
+  [ `Obstruction_free; `Lock_free ]
   |> List.iter @@ fun mode ->
      let barrier = Barrier.make 2
      and n_iter = 100 * Util.iter_factor
@@ -63,7 +63,7 @@ let test_non_linearizable_xt () =
      in
 
      let atomically tx =
-       if Random.bool () then Xt.commit ~mode:Mode.obstruction_free tx
+       if Random.bool () then Xt.commit ~mode:`Obstruction_free tx
        else Xt.commit tx
      in
 
@@ -103,7 +103,7 @@ let test_set () =
 (* *)
 
 let test_no_skew_xt () =
-  [ Mode.obstruction_free; Mode.lock_free ]
+  [ `Obstruction_free; `Lock_free ]
   |> List.iter @@ fun mode ->
      let barrier = Barrier.make 3 in
      let test_finished = Atomic.make false in
@@ -168,7 +168,7 @@ let test_no_skew_xt () =
 (* *)
 
 let test_get_seq_xt () =
-  [ Mode.obstruction_free; Mode.lock_free ]
+  [ `Obstruction_free; `Lock_free ]
   |> List.iter @@ fun mode ->
      let barrier = Barrier.make 4 in
      let test_finished = Atomic.make false in
@@ -225,7 +225,7 @@ let test_get_seq_xt () =
 (* *)
 
 let test_stress_xt n nb_loop =
-  [ Mode.obstruction_free; Mode.lock_free ]
+  [ `Obstruction_free; `Lock_free ]
   |> List.iter @@ fun mode ->
      let make_loc n =
        let rec loop n out =
@@ -326,7 +326,7 @@ let test_post_commit () =
     begin
       try
         count := 0;
-        Xt.commit ~mode:Mode.obstruction_free { tx }
+        Xt.commit ~mode:`Obstruction_free { tx }
       with Exit -> ()
     end;
     assert (!count = expect)
@@ -613,11 +613,9 @@ let test_timeout () =
 (* *)
 
 let test_mode () =
-  assert (Loc.get_mode (Loc.make ~mode:Mode.lock_free 0) == Mode.lock_free);
-  assert (
-    Loc.get_mode (Loc.make ~mode:Mode.obstruction_free 0)
-    == Mode.obstruction_free);
-  assert (Loc.get_mode (Loc.make 0) == Mode.obstruction_free)
+  assert (Loc.get_mode (Loc.make ~mode:`Lock_free 0) == `Lock_free);
+  assert (Loc.get_mode (Loc.make ~mode:`Obstruction_free 0) == `Obstruction_free);
+  assert (Loc.get_mode (Loc.make 0) == `Obstruction_free)
 
 (* *)
 


### PR DESCRIPTION
This improves the internals by "inlining" the transaction log record, which eliminates an indirection and avoids a write barrier per transaction.  This slightly reduces the overhead of transactions.

This PR also changes the optional mode argument to use a polymorphic variant, which makes the API slightly more convenient.