### PR TITLE
Add `?backoff` to `Loc.compare_and_set`

### DIFF
--- a/src/kcas/kcas.mli
+++ b/src/kcas/kcas.mli
@@ -215,7 +215,7 @@ module Loc : sig
       conditional load.  It is also safe for the given function [f] to raise any
       other exception to abort the conditional load. *)
 
-  val compare_and_set : 'a t -> 'a -> 'a -> bool
+  val compare_and_set : ?backoff:Backoff.t -> 'a t -> 'a -> 'a -> bool
   (** [compare_and_set r before after] atomically updates the shared memory
       location [r] to the [after] value if the current value of [r] is the
       [before] value. *)


### PR DESCRIPTION
`Loc.compare_and_set` has a mutating retry loop, so it makes sense to include a backoff mechanism.

This PR also adds backoff when removing awaiters.