### PR TITLE
Add `get`, `push & pop`, `cas`, `xchg`, and `swap` 1-`Loc` benchmarks

### DIFF
--- a/bench/bench_loc.ml
+++ b/bench/bench_loc.ml
@@ -1,15 +1,19 @@
 open Kcas
 open Bench
 
-let run_one ?(factor = 1) ?(n_iter = 25 * factor * Util.iter_factor) () =
-  let loc = Loc.make 0 in
+type t = Op : string * 'a * ('a Loc.t -> unit) * ('a Loc.t -> unit) -> t
+
+let run_one ?(factor = 1) ?(n_iter = 25 * factor * Util.iter_factor)
+    (Op (name, value, op1, op2)) =
+  let loc = Loc.make value in
 
   let init _ = () in
   let work _ () =
     let rec loop i =
       if i > 0 then begin
-        Loc.incr loc;
-        loop (i - 1)
+        op1 loc;
+        op2 loc;
+        loop (i - 2)
       end
     in
     loop n_iter
@@ -21,12 +25,32 @@ let run_one ?(factor = 1) ?(n_iter = 25 * factor * Util.iter_factor) () =
     [
       Stats.of_times times
       |> Stats.scale (1_000_000_000.0 /. Float.of_int n_iter)
-      |> Stats.to_json ~name:"time per op/incr"
+      |> Stats.to_json
+           ~name:(Printf.sprintf "time per op/%s" name)
            ~description:"Time to perform a single op" ~units:"ns";
       Times.invert times |> Stats.of_times
       |> Stats.scale (Float.of_int n_iter /. 1_000_000.0)
-      |> Stats.to_json ~name:"ops over time/incr"
+      |> Stats.to_json
+           ~name:(Printf.sprintf "ops over time/%s" name)
            ~description:"Number of operations performed over time" ~units:"M/s";
     ]
 
-let run_suite ~factor = run_one ~factor ()
+let run_suite ~factor =
+  [
+    (let get x = Loc.get x |> ignore in
+     Op ("get", 42, get, get));
+    (let incr x = Loc.incr x in
+     Op ("incr", 0, incr, incr));
+    (let push x = Loc.modify x (fun xs -> 101 :: xs)
+     and pop x = Loc.modify x (function [] -> [] | _ :: xs -> xs) in
+     Op ("push & pop", [], push, pop));
+    (let cas01 x = Loc.compare_and_set x 0 1 |> ignore
+     and cas10 x = Loc.compare_and_set x 1 0 |> ignore in
+     Op ("cas int", 0, cas01, cas10));
+    (let xchg1 x = Loc.exchange x 1 |> ignore
+     and xchg0 x = Loc.exchange x 0 |> ignore in
+     Op ("xchg int", 0, xchg1, xchg0));
+    (let swap x = Loc.modify x (fun (x, y) -> (y, x)) in
+     Op ("swap", (4, 2), swap, swap));
+  ]
+  |> List.concat_map @@ run_one ~factor


### PR DESCRIPTION
This PR adds more single location benchmarks.