### PR TITLE
Use a wall time budget for benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	@dune runtest --force
 
 bench:
-	@dune exec --release -- bench/main.exe 10
+	@dune exec --release -- bench/main.exe -budget 1
 
 clean:
 	@dune clean

--- a/bench/barrier.ml
+++ b/bench/barrier.ml
@@ -1,6 +1,8 @@
 type t = { counter : int Atomic.t; total : int }
 
-let make total = { counter = Atomic.make 0; total }
+let make total =
+  { counter = Atomic.make 0 |> Multicore_magic.copy_as_padded; total }
+  |> Multicore_magic.copy_as_padded
 
 let await { counter; total } =
   if Atomic.get counter = total then

--- a/bench/bench.mli
+++ b/bench/bench.mli
@@ -3,8 +3,9 @@ module Times : sig
 
   val record :
     n_domains:int ->
+    budgetf:float ->
     ?n_warmups:int ->
-    ?n_runs:int ->
+    ?n_runs_min:int ->
     ?before:(unit -> unit) ->
     init:(int -> 's) ->
     work:(int -> 's -> unit) ->

--- a/bench/bench_accumulator.ml
+++ b/bench/bench_accumulator.ml
@@ -1,8 +1,7 @@
 open Kcas_data
 open Bench
 
-let run_one ~n_domains ?(factor = 1) ?(n_ops = 60 * factor * Util.iter_factor)
-    () =
+let run_one ~budgetf ~n_domains ?(n_ops = 180 * Util.iter_factor) () =
   let n_ops = n_ops * n_domains in
 
   let t = Accumulator.make 0 in
@@ -30,7 +29,7 @@ let run_one ~n_domains ?(factor = 1) ?(n_ops = 60 * factor * Util.iter_factor)
 
   let after () = Atomic.set n_ops_todo n_ops in
 
-  let times = Times.record ~n_domains ~init ~work ~after () in
+  let times = Times.record ~n_domains ~budgetf ~init ~work ~after () in
 
   let name metric =
     Printf.sprintf "%s/%d worker%s, 0%% reads" metric n_domains
@@ -53,6 +52,6 @@ let run_one ~n_domains ?(factor = 1) ?(n_ops = 60 * factor * Util.iter_factor)
            ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   [ 1; 2; 4 ]
-  |> List.concat_map @@ fun n_domains -> run_one ~n_domains ~factor ()
+  |> List.concat_map @@ fun n_domains -> run_one ~n_domains ~budgetf ()

--- a/bench/bench_atomic.ml
+++ b/bench/bench_atomic.ml
@@ -13,7 +13,7 @@ end
 type t =
   | Op : string * int * 'a * ('a Atomic.t -> unit) * ('a Atomic.t -> unit) -> t
 
-let run_one ?(factor = 1) ?(n_iter = 50 * factor * Util.iter_factor)
+let run_one ~budgetf ?(n_iter = 500 * Util.iter_factor)
     (Op (name, extra, value, op1, op2)) =
   let n_iter = n_iter * extra in
 
@@ -31,7 +31,7 @@ let run_one ?(factor = 1) ?(n_iter = 50 * factor * Util.iter_factor)
     loop n_iter
   in
 
-  let times = Times.record ~n_domains:1 ~init ~work () in
+  let times = Times.record ~n_domains:1 ~budgetf ~init ~work () in
 
   List.concat
     [
@@ -47,7 +47,7 @@ let run_one ?(factor = 1) ?(n_iter = 50 * factor * Util.iter_factor)
            ~description:"Number of operations performed over time" ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   [
     (let get x = Atomic.get x |> ignore in
      Op ("get", 10, 42, get, get));
@@ -65,4 +65,4 @@ let run_suite ~factor =
     (let swap x = Atomic.modify x (fun (x, y) -> (y, x)) in
      Op ("swap", 2, (4, 2), swap, swap));
   ]
-  |> List.concat_map @@ run_one ~factor
+  |> List.concat_map @@ run_one ~budgetf

--- a/bench/bench_dllist.ml
+++ b/bench/bench_dllist.ml
@@ -1,7 +1,7 @@
 open Kcas_data
 open Bench
 
-let run_single ?(factor = 1) ?(n_msgs = 10 * factor * Util.iter_factor) () =
+let run_single ~budgetf ?(n_msgs = 15 * Util.iter_factor) () =
   let t = Dllist.create () in
 
   let init _ = () in
@@ -12,7 +12,7 @@ let run_single ?(factor = 1) ?(n_msgs = 10 * factor * Util.iter_factor) () =
     done
   in
 
-  let times = Times.record ~n_domains:1 ~init ~work () in
+  let times = Times.record ~n_domains:1 ~budgetf ~init ~work () in
 
   let name metric = Printf.sprintf "%s/single-domain" metric in
 
@@ -33,8 +33,8 @@ let run_single ?(factor = 1) ?(n_msgs = 10 * factor * Util.iter_factor) () =
            ~units:"M/s";
     ]
 
-let run_one ?(n_adders = 2) ?(n_takers = 2) ?(factor = 1)
-    ?(n_msgs = 50 * factor * Util.iter_factor) () =
+let run_one ~budgetf ?(n_adders = 2) ?(n_takers = 2) ?(factor = 1)
+    ?(n_msgs = 20 * factor * Util.iter_factor) () =
   let n_domains = n_adders + n_takers in
 
   let t = Dllist.create () in
@@ -74,7 +74,7 @@ let run_one ?(n_adders = 2) ?(n_takers = 2) ?(factor = 1)
     Atomic.set n_msgs_to_add n_msgs
   in
 
-  let times = Times.record ~n_domains ~init ~work ~after () in
+  let times = Times.record ~n_domains ~budgetf ~init ~work ~after () in
 
   let name metric =
     let format role blocking n =
@@ -105,8 +105,8 @@ let run_one ?(n_adders = 2) ?(n_takers = 2) ?(factor = 1)
            ~units:"M/s";
     ]
 
-let run_suite ~factor =
-  run_single ~factor ()
+let run_suite ~budgetf =
+  run_single ~budgetf ()
   @ (Util.cross [ 1; 2 ] [ 1; 2 ]
     |> List.concat_map @@ fun (n_adders, n_takers) ->
-       run_one ~n_adders ~n_takers ~factor ())
+       run_one ~budgetf ~n_adders ~n_takers ())

--- a/bench/bench_hashtbl.ml
+++ b/bench/bench_hashtbl.ml
@@ -7,7 +7,7 @@ module Int = struct
   let hash = Fun.id
 end
 
-let run_one ~n_domains ?(factor = 1) ?(n_ops = 50 * factor * Util.iter_factor)
+let run_one ~budgetf ~n_domains ?(n_ops = 40 * Util.iter_factor)
     ?(n_keys = 1000) ~percent_read () =
   let t = Hashtbl.create ~hashed_type:(module Int) () in
 
@@ -48,7 +48,7 @@ let run_one ~n_domains ?(factor = 1) ?(n_ops = 50 * factor * Util.iter_factor)
   in
   let after () = Atomic.set n_ops_todo n_ops in
 
-  let times = Times.record ~n_domains ~init ~work ~after () in
+  let times = Times.record ~n_domains ~budgetf ~init ~work ~after () in
 
   let name metric =
     Printf.sprintf "%s/%d worker%s, %d%% reads" metric n_domains
@@ -73,7 +73,7 @@ let run_one ~n_domains ?(factor = 1) ?(n_ops = 50 * factor * Util.iter_factor)
            ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   Util.cross [ 90; 50; 10 ] [ 1; 2; 4 ]
   |> List.concat_map @@ fun (percent_read, n_domains) ->
-     run_one ~n_domains ~percent_read ~factor ()
+     run_one ~budgetf ~n_domains ~percent_read ()

--- a/bench/bench_loc.ml
+++ b/bench/bench_loc.ml
@@ -3,7 +3,7 @@ open Bench
 
 type t = Op : string * int * 'a * ('a Loc.t -> unit) * ('a Loc.t -> unit) -> t
 
-let run_one ?(factor = 1) ?(n_iter = 25 * factor * Util.iter_factor)
+let run_one ~budgetf ?(n_iter = 250 * Util.iter_factor)
     (Op (name, extra, value, op1, op2)) =
   let n_iter = n_iter * extra in
 
@@ -21,7 +21,7 @@ let run_one ?(factor = 1) ?(n_iter = 25 * factor * Util.iter_factor)
     loop n_iter
   in
 
-  let times = Times.record ~n_domains:1 ~init ~work () in
+  let times = Times.record ~n_domains:1 ~budgetf ~init ~work () in
 
   List.concat
     [
@@ -37,7 +37,7 @@ let run_one ?(factor = 1) ?(n_iter = 25 * factor * Util.iter_factor)
            ~description:"Number of operations performed over time" ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   [
     (let get x = Loc.get x |> ignore in
      Op ("get", 5, 42, get, get));
@@ -55,4 +55,4 @@ let run_suite ~factor =
     (let swap x = Loc.modify x (fun (x, y) -> (y, x)) in
      Op ("swap", 1, (4, 2), swap, swap));
   ]
-  |> List.concat_map @@ run_one ~factor
+  |> List.concat_map @@ run_one ~budgetf

--- a/bench/bench_mvar.ml
+++ b/bench/bench_mvar.ml
@@ -1,9 +1,8 @@
 open Kcas_data
 open Bench
 
-let run_one ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
-    ?(blocking_take = false) ?(factor = 1)
-    ?(n_msgs = 2 * factor * Util.iter_factor) () =
+let run_one ~budgetf ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
+    ?(blocking_take = false) ?(n_msgs = 2 * Util.iter_factor) () =
   let n_domains = n_adders + n_takers in
 
   let t = Mvar.create None in
@@ -68,7 +67,7 @@ let run_one ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
     Atomic.set n_msgs_to_add n_msgs
   in
 
-  let times = Times.record ~n_domains ~init ~work ~after () in
+  let times = Times.record ~n_domains ~budgetf ~init ~work ~after () in
 
   let name metric =
     let format role blocking n =
@@ -99,10 +98,10 @@ let run_one ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
            ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   Util.cross
     (Util.cross [ 1; 2 ] [ false; true ])
     (Util.cross [ 1; 2 ] [ false; true ])
   |> List.concat_map
      @@ fun ((n_adders, blocking_add), (n_takers, blocking_take)) ->
-     run_one ~n_adders ~blocking_add ~n_takers ~blocking_take ~factor ()
+     run_one ~budgetf ~n_adders ~blocking_add ~n_takers ~blocking_take ()

--- a/bench/bench_parallel_cmp.ml
+++ b/bench/bench_parallel_cmp.ml
@@ -1,8 +1,7 @@
 open Kcas
 open Bench
 
-let run_one ~n_domains ?(factor = 1) ?(n_ops = 50 * factor * Util.iter_factor)
-    () =
+let run_one ~budgetf ~n_domains ?(n_ops = 50 * Util.iter_factor) () =
   let n_ops = n_ops * n_domains in
 
   let a = Loc.make ~padded:true 10 in
@@ -38,7 +37,7 @@ let run_one ~n_domains ?(factor = 1) ?(n_ops = 50 * factor * Util.iter_factor)
 
   let after () = Atomic.set n_ops_todo n_ops in
 
-  let times = Times.record ~n_domains ~init ~work ~after () in
+  let times = Times.record ~n_domains ~budgetf ~init ~work ~after () in
 
   let name metric =
     Printf.sprintf "%s/%d worker%s" metric n_domains
@@ -61,6 +60,6 @@ let run_one ~n_domains ?(factor = 1) ?(n_ops = 50 * factor * Util.iter_factor)
            ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   [ 1; 2; 4 ]
-  |> List.concat_map @@ fun n_domains -> run_one ~n_domains ~factor ()
+  |> List.concat_map @@ fun n_domains -> run_one ~budgetf ~n_domains ()

--- a/bench/bench_queue.ml
+++ b/bench/bench_queue.ml
@@ -1,9 +1,8 @@
 open Kcas_data
 open Bench
 
-let run_one ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
-    ?(blocking_take = false) ?(factor = 1)
-    ?(n_msgs = 50 * factor * Util.iter_factor) () =
+let run_one ~budgetf ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
+    ?(blocking_take = false) ?(n_msgs = 50 * Util.iter_factor) () =
   let n_domains = n_adders + n_takers in
 
   let t = Queue.create () in
@@ -54,7 +53,7 @@ let run_one ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
     Atomic.set n_msgs_to_add n_msgs
   in
 
-  let times = Times.record ~n_domains ~init ~work ~after () in
+  let times = Times.record ~n_domains ~budgetf ~init ~work ~after () in
 
   let name metric =
     let format role blocking n =
@@ -85,10 +84,10 @@ let run_one ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
            ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   Util.cross
     (Util.cross [ 1; 2 ] [ false ])
     (Util.cross [ 1; 2 ] [ false; true ])
   |> List.concat_map
      @@ fun ((n_adders, blocking_add), (n_takers, blocking_take)) ->
-     run_one ~n_adders ~blocking_add ~n_takers ~blocking_take ~factor ()
+     run_one ~budgetf ~n_adders ~blocking_add ~n_takers ~blocking_take ()

--- a/bench/bench_stack.ml
+++ b/bench/bench_stack.ml
@@ -1,9 +1,8 @@
 open Kcas_data
 open Bench
 
-let run_one ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
-    ?(blocking_take = false) ?(factor = 1)
-    ?(n_msgs = 25 * factor * Util.iter_factor) () =
+let run_one ~budgetf ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
+    ?(blocking_take = false) ?(n_msgs = 50 * Util.iter_factor) () =
   let n_domains = n_adders + n_takers in
 
   let t = Stack.create () in
@@ -54,7 +53,7 @@ let run_one ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
     Atomic.set n_msgs_to_add n_msgs
   in
 
-  let times = Times.record ~n_domains ~init ~work ~after () in
+  let times = Times.record ~n_domains ~budgetf ~init ~work ~after () in
 
   let name metric =
     let format role blocking n =
@@ -85,10 +84,10 @@ let run_one ?(n_adders = 2) ?(blocking_add = false) ?(n_takers = 2)
            ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   Util.cross
     (Util.cross [ 1; 2 ] [ false ])
     (Util.cross [ 1; 2 ] [ false; true ])
   |> List.concat_map
      @@ fun ((n_adders, blocking_add), (n_takers, blocking_take)) ->
-     run_one ~n_adders ~blocking_add ~n_takers ~blocking_take ~factor ()
+     run_one ~budgetf ~n_adders ~blocking_add ~n_takers ~blocking_take ()

--- a/bench/bench_xt.ml
+++ b/bench/bench_xt.ml
@@ -1,8 +1,8 @@
 open Kcas
 open Bench
 
-let run_one ?(n_locs = 2) ?(factor = 1)
-    ?(n_iter = 10 * factor * Util.iter_factor) () =
+let run_one ~budgetf ?(n_locs = 2)
+    ?(n_iter = 15 * (9 - n_locs) * Util.iter_factor) () =
   let locs = Loc.make_array n_locs 0 in
   let rec loop ~xt i =
     Xt.incr ~xt (Array.unsafe_get locs i);
@@ -25,7 +25,7 @@ let run_one ?(n_locs = 2) ?(factor = 1)
     loop n_iter
   in
 
-  let times = Times.record ~n_domains:1 ~init ~work () in
+  let times = Times.record ~n_domains:1 ~budgetf ~init ~work () in
 
   let name metric = Printf.sprintf "%s/%d loc tx" metric n_locs in
 
@@ -44,10 +44,6 @@ let run_one ?(n_locs = 2) ?(factor = 1)
            ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   [ 0; 1; 2; 4; 8 ]
-  |> List.concat_map @@ fun n_locs ->
-     let factor =
-       Float.to_int (Float.of_int factor *. 9.0 /. Float.of_int (n_locs + 1))
-     in
-     run_one ~n_locs ~factor ()
+  |> List.concat_map @@ fun n_locs -> run_one ~budgetf ~n_locs ()

--- a/bench/bench_xt_ro.ml
+++ b/bench/bench_xt_ro.ml
@@ -1,8 +1,8 @@
 open Kcas
 open Bench
 
-let run_one ?(n_locs = 2) ?(factor = 1)
-    ?(n_iter = 10 * factor * Util.iter_factor) () =
+let run_one ~budgetf ?(n_locs = 2)
+    ?(n_iter = 20 * (9 - n_locs) * Util.iter_factor) () =
   let locs = Loc.make_array n_locs 0 in
   let rec loop ~xt s i =
     let s = s + Xt.get ~xt (Array.unsafe_get locs i) in
@@ -25,7 +25,7 @@ let run_one ?(n_locs = 2) ?(factor = 1)
     loop n_iter
   in
 
-  let times = Times.record ~n_domains:1 ~init ~work () in
+  let times = Times.record ~n_domains:1 ~budgetf ~init ~work () in
 
   let name metric = Printf.sprintf "%s/%d loc tx" metric n_locs in
 
@@ -44,10 +44,6 @@ let run_one ?(n_locs = 2) ?(factor = 1)
            ~units:"M/s";
     ]
 
-let run_suite ~factor =
+let run_suite ~budgetf =
   [ 0; 1; 2; 4; 8 ]
-  |> List.concat_map @@ fun n_locs ->
-     let factor =
-       Float.to_int (Float.of_int factor *. 9.0 /. Float.of_int (n_locs + 1))
-     in
-     run_one ~n_locs ~factor ()
+  |> List.concat_map @@ fun n_locs -> run_one ~budgetf ~n_locs ()

--- a/bench/dune
+++ b/bench/dune
@@ -8,5 +8,6 @@
   multicore-magic
   yojson
   domain_shims
+  str
   mtime
   mtime.clock.os))

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -22,16 +22,53 @@ let rec replace_inf : Yojson.Safe.t -> Yojson.Safe.t = function
   | `Variant (k, vo) -> `Variant (k, Option.map replace_inf vo)
 
 let () =
-  let factor = try int_of_string Sys.argv.(1) with _ -> 1 in
+  let budgetf = ref 0.025 in
+  let filters = ref [] in
 
-  let benchmarks = benchmarks in
+  let rec specs =
+    [
+      ("-budget", Arg.Set_float budgetf, "seconds\t  Budget for a benchmark");
+      ("-help", Unit help, "\t  Show this help message");
+      ("--help", Unit help, "\t  Show this help message");
+    ]
+  and help () =
+    Arg.usage (Arg.align specs)
+      (Printf.sprintf
+         "\n\
+          Usage: %s <option>* filter*\n\n\
+          The filters are regular expressions for selecting benchmarks to run.\n\n\
+          Benchmarks:\n\n\
+          %s\n\n\
+          Options:\n"
+         (Filename.basename Sys.argv.(0))
+         (benchmarks
+         |> List.map (fun (name, _) -> "  " ^ name)
+         |> String.concat "\n"));
+    exit 1
+  in
+  Arg.parse specs (fun filter -> filters := filter :: !filters) "";
+
+  let budgetf = !budgetf in
 
   let run (name, fn) =
-    Gc.full_major ();
-    let metrics = fn ~factor in
+    let metrics = fn ~budgetf in
     `Assoc [ ("name", `String name); ("metrics", `List metrics) ]
   in
 
-  `Assoc [ ("results", `List (List.map run benchmarks)) ]
+  let filter =
+    match !filters with
+    | [] -> Fun.const true
+    | filters -> (
+        let regexps = filters |> List.map Str.regexp in
+        fun (name, _) ->
+          regexps
+          |> List.exists @@ fun regexp ->
+             match Str.search_forward regexp name 0 with
+             | _ -> true
+             | exception Not_found -> false)
+  in
+
+  `Assoc
+    [ ("results", `List (benchmarks |> List.filter filter |> List.map run)) ]
   |> replace_inf
   |> Yojson.Safe.pretty_print ~std:true Format.std_formatter


### PR DESCRIPTION
This PR changes the benchmark runner to use a time budget rather than a fixed number of runs.  The iteration counts of many of the bechmarks are also adjusted in an attempt to improve stability.  This PR also adds the ability to filter (or select) benchmarks to run.