### PR TITLE
Make the `Loc` constructor private

### DIFF
--- a/src/kcas/kcas.ml
+++ b/src/kcas/kcas.ml
@@ -560,7 +560,7 @@ let inc x = x + 1
 let dec x = x - 1
 
 module Loc = struct
-  type !'a t = Loc : { state : 'state; id : 'id } -> 'a t
+  type !'a t = private Loc : { state : 'state; id : 'id } -> 'a t
 
   external of_loc : 'a loc -> 'a t = "%identity"
   external to_loc : 'a t -> 'a loc = "%identity"

--- a/src/kcas/kcas.mli
+++ b/src/kcas/kcas.mli
@@ -177,10 +177,10 @@ end
     usually need not worry about. *)
 module Loc : sig
   (** Type of shared memory locations. *)
-  type !'a t =
+  type !'a t = private
     | Loc : { state : 'state; id : 'id } -> 'a t
         (** The shape is transparent to allow the compiler to perform
-            optimizations on array accesses.  User code should treat this tyoe
+            optimizations on array accesses.  User code should treat this type
             as abstract. *)
 
   val make : ?padded:bool -> ?mode:Mode.t -> 'a -> 'a t


### PR DESCRIPTION
This makes the `Loc` constructor `private` to further disencourage abuse.