### PR TITLE
Copy opam files before opam update

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,9 +1,9 @@
 FROM ocaml/opam:debian-ocaml-5.1
 RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 WORKDIR bench-dir
+COPY *.opam ./
 RUN opam remote add origin https://opam.ocaml.org && \
     opam update
-COPY *.opam ./
 RUN opam pin -yn --with-version=dev .
 RUN opam install -y --deps-only --with-test .
 COPY . ./


### PR DESCRIPTION
This should ensure that changing dependencies will rerun `opam update`.