### PR TITLE
Adjust COC contacts

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,6 +10,5 @@ This project follows the OCaml Code of Conduct
 
 To report any violations, please contact:
 
-- Vesa Karvonen <vesa [at] tarides [dot] com>
 - Carine Morel <carine [at] tarides [dot] com>
 - Sudha Parimala <sudha [at] tarides [dot] com>


### PR DESCRIPTION
I do not want to be a contact for COC violations.

Do we need to have three COC contacts?

If so, perhaps someone else volunteers and can be added as a contact.
