### PR TITLE
Require sherlodoc and dune 3.14

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.8)
+(lang dune 3.14)
 
 (name kcas)
 
@@ -52,9 +52,13 @@
    (and
     (>= 2.3.0)
     :with-test))
+  (sherlodoc
+   (and
+    (>= 0.2)
+    :with-doc))
   (odoc
    (and
-    (>= 2.2.0)
+    (>= 2.4.1)
     :with-doc))))
 
 (package
@@ -100,7 +104,11 @@
    (and
     (>= 2.3.0)
     :with-test))
+  (sherlodoc
+   (and
+    (>= 0.2)
+    :with-doc))
   (odoc
    (and
-    (>= 2.2.0)
+    (>= 2.4.1)
     :with-doc))))

--- a/kcas.opam
+++ b/kcas.opam
@@ -16,7 +16,7 @@ license: "ISC"
 homepage: "https://github.com/ocaml-multicore/kcas"
 bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.14"}
   "ocaml" {>= "4.13.0"}
   "backoff" {>= "0.1.0"}
   "domain-local-await" {>= "1.0.1"}
@@ -25,7 +25,8 @@ depends: [
   "domain_shims" {>= "0.1.0" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
   "mdx" {>= "2.3.0" & with-test}
-  "odoc" {>= "2.2.0" & with-doc}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/kcas_data.opam
+++ b/kcas_data.opam
@@ -16,7 +16,7 @@ license: "ISC"
 homepage: "https://github.com/ocaml-multicore/kcas"
 bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.14"}
   "kcas" {= version}
   "multicore-magic" {>= "2.1.0"}
   "backoff" {>= "0.1.0" & with-test}
@@ -27,7 +27,8 @@ depends: [
   "qcheck-core" {>= "0.21.2" & with-test}
   "qcheck-stm" {>= "0.3" & with-test}
   "mdx" {>= "2.3.0" & with-test}
-  "odoc" {>= "2.2.0" & with-doc}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
The new dune has sherlodoc integration to produce HTML documentation with a search bar.