### PR TITLE
Require multicore-bench 0.1.5

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-ocaml-5.2
+WORKDIR /bench-dir
 RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
-WORKDIR bench-dir
 RUN sudo chown opam .
 COPY *.opam ./
 RUN opam remote add origin https://github.com/ocaml/opam-repository.git && \

--- a/dune-project
+++ b/dune-project
@@ -94,7 +94,7 @@
     :with-test))
   (multicore-bench
    (and
-    (>= 0.1.4)
+    (>= 0.1.5)
     :with-test))
   (alcotest
    (and

--- a/kcas_data.opam
+++ b/kcas_data.opam
@@ -22,7 +22,7 @@ depends: [
   "backoff" {>= "0.1.0" & with-test}
   "domain-local-await" {>= "1.0.1" & with-test}
   "domain_shims" {>= "0.1.0" & with-test}
-  "multicore-bench" {>= "0.1.4" & with-test}
+  "multicore-bench" {>= "0.1.5" & with-test}
   "alcotest" {>= "1.8.0" & with-test}
   "qcheck-core" {>= "0.21.2" & with-test}
   "qcheck-stm" {>= "0.3" & with-test}


### PR DESCRIPTION
The new version has improved error handling to help ensure that benchmarks terminate even when they might raise unexpectedly.